### PR TITLE
Fix bugs including multiple duplicate query bundles and duplicate statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 .settings
 .checkstyle
 *~
-/queryall-webapp/pom.xml.versionsBackup
-/queryall-reasoner/pom.xml.versionsBackup
+pom.xml.versionsBackup

--- a/pom.xml
+++ b/pom.xml
@@ -2,6 +2,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
+
 	<groupId>org.queryall</groupId>
 	<artifactId>queryall-parent</artifactId>
 	<version>1.3.1-SNAPSHOT</version>
@@ -20,16 +27,15 @@
 		<module>queryall-lib-test</module>
 		<module>queryall-content-negotiation</module>
 		<module>queryall-webapp</module>
-		<!-- Hidden temporarily from reactor <module>queryall-ext-rule-spin</module> -->
 	</modules>
 	<name>Queryall RDF services</name>
-	<description>A package of services enabling access to a variety of datasources, with the results normalised to a single browsable Linked Data set of results.</description>
+	<description>A package of services enabling access to a variety of RDF datasources, with the results normalised to a single browsable Linked Data set of results.</description>
 	<url>http://sourceforge.net/apps/mediawiki/bio2rdf/</url>
 	<inceptionYear>2007</inceptionYear>
 	<scm>
-		<connection>scm:git:git://bio2rdf.git.sourceforge.net/gitroot/queryall/</connection>
-		<developerConnection>scm:git:ssh://p_ansell@bio2rdf.git.sourceforge.net/gitroot/queryall/</developerConnection>
-		<url>http://bio2rdf.git.sourceforge.net/</url>
+		<connection>scm:git:git@github.com:bio2rdf/queryall.git</connection>
+		<developerConnection>scm:git:git@github.com:bio2rdf/queryall.git</developerConnection>
+		<url>git@github.com:bio2rdf/queryall.git</url>
 	</scm>
 	<developers>
 		<developer>
@@ -451,17 +457,6 @@
 			</snapshots>
 		</repository>
 		<repository>
-			<id>on.cs.unibas.ch</id>
-			<name>DBIS Maven Releases Repository</name>
-			<url>http://on.cs.unibas.ch/maven/repository</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</repository>
-		<repository>
 			<id>fortytwo.net</id>
 			<name>SesameTools Repository</name>
 			<url>http://fortytwo.net/maven2</url>
@@ -473,16 +468,24 @@
 			</snapshots>
 		</repository>
 	</repositories>
-	<distributionManagement>
-		<repository>
-			<id>maenad-releases</id>
-			<name>maenad-releases</name>
-			<url>http://maven.metadata.net/artifactory/libs-releases-local</url>
-		</repository>
-		<snapshotRepository>
-			<id>maenad-snapshots</id>
-			<name>maenad-snapshots</name>
-			<url>http://maven.metadata.net/artifactory/libs-snapshots-local</url>
-		</snapshotRepository>
-	</distributionManagement>
+	<profiles>
+		<profile>
+			<id>metadatanet-deploy</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<distributionManagement>
+				<repository>
+					<id>maenad-releases</id>
+					<name>maenad-releases</name>
+					<url>http://maven.metadata.net/artifactory/libs-releases-local</url>
+				</repository>
+				<snapshotRepository>
+					<id>maenad-snapshots</id>
+					<name>maenad-snapshots</name>
+					<url>http://maven.metadata.net/artifactory/libs-snapshots-local</url>
+				</snapshotRepository>
+			</distributionManagement>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<version>7</version>
 	</parent>
 
-	<groupId>org.queryall</groupId>
+	<groupId>com.github.queryall</groupId>
 	<artifactId>queryall-parent</artifactId>
 	<version>1.3.1-SNAPSHOT</version>
 	<packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.queryall</groupId>
 	<artifactId>queryall-parent</artifactId>
-	<version>1.3</version>
+	<version>1.3.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<modules>
 		<module>queryall-api</module>
@@ -58,7 +58,7 @@
 		<junit.version>4.10</junit.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<queryall.version>1.3</queryall.version>
+		<queryall.version>1.3.1-SNAPSHOT</queryall.version>
 		<sesame.version>2.6.5</sesame.version>
 		<sesametools.version>1.6</sesametools.version>
 		<slf4j.version>1.6.4</slf4j.version>

--- a/queryall-api/pom.xml
+++ b/queryall-api/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<artifactId>queryall-parent</artifactId>
 		<version>1.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>

--- a/queryall-api/pom.xml
+++ b/queryall-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.queryall</groupId>
 		<artifactId>queryall-parent</artifactId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/queryall-api/src/main/java/org/queryall/api/base/BaseQueryAllInterface.java
+++ b/queryall-api/src/main/java/org/queryall/api/base/BaseQueryAllInterface.java
@@ -38,6 +38,8 @@ public interface BaseQueryAllInterface
     /**
      * Returns the namespace used for objects of this type by default. For example, it would
      * correspond to namespaceString in the following: http://myhost.org/namespaceString:identifier
+     * 
+     * This should be consistent with the results of QueryAllNamespaces.getDefaultNamespace(this);
      **/
     QueryAllNamespaces getDefaultNamespace();
     

--- a/queryall-api/src/main/java/org/queryall/api/utils/QueryAllNamespaces.java
+++ b/queryall-api/src/main/java/org/queryall/api/utils/QueryAllNamespaces.java
@@ -3,6 +3,16 @@
  */
 package org.queryall.api.utils;
 
+import org.queryall.api.base.BaseQueryAllInterface;
+import org.queryall.api.namespace.NamespaceEntry;
+import org.queryall.api.profile.Profile;
+import org.queryall.api.project.Project;
+import org.queryall.api.provider.Provider;
+import org.queryall.api.querytype.QueryType;
+import org.queryall.api.rdfrule.NormalisationRule;
+import org.queryall.api.ruletest.RuleTest;
+import org.queryall.exception.QueryAllRuntimeException;
+
 /**
  * Generates the namespace ontology URIs based on calls to PropertyUtils.
  * 
@@ -130,6 +140,54 @@ public enum QueryAllNamespaces
     private static String prefix = PropertyUtils.getSystemOrPropertyString("queryall.ontologyPrefix",
             "http://purl.org/queryall/");
     private static String suffix = PropertyUtils.getSystemOrPropertyString("queryall.ontologySuffix", ":");
+    
+    /**
+     * Return a mapping for the QueryAllNamespaces defined here which are also BaseQueryAllInterface
+     * objects. Note, that some of the QueryAllNamespaces are not represented here as they do not
+     * have a mapping to the BaseQueryAllInterface hierarchy.
+     * 
+     * @param object
+     * @return A QueryAllNamespaces enum object matching the given object
+     * @throws QueryAllRuntimeException
+     *             if the object was not mapped to the QueryAllNamespaces hierarchy.
+     */
+    public static QueryAllNamespaces getDefaultNamespace(final BaseQueryAllInterface object)
+        throws QueryAllRuntimeException
+    {
+        if(object instanceof NamespaceEntry)
+        {
+            return QueryAllNamespaces.NAMESPACEENTRY;
+        }
+        else if(object instanceof Profile)
+        {
+            return QueryAllNamespaces.PROFILE;
+        }
+        else if(object instanceof Project)
+        {
+            return QueryAllNamespaces.PROJECT;
+        }
+        else if(object instanceof Provider)
+        {
+            return QueryAllNamespaces.PROVIDER;
+        }
+        else if(object instanceof QueryType)
+        {
+            return QueryAllNamespaces.QUERY;
+        }
+        else if(object instanceof NormalisationRule)
+        {
+            return QueryAllNamespaces.RDFRULE;
+        }
+        else if(object instanceof RuleTest)
+        {
+            return QueryAllNamespaces.RULETEST;
+        }
+        else
+        {
+            throw new QueryAllRuntimeException(
+                    "Could not determine the QueryAllNamespace for the given BaseQueryAllInterface object");
+        }
+    }
     
     private String baseUri;
     

--- a/queryall-api/src/main/java/org/queryall/api/utils/WebappConfig.java
+++ b/queryall-api/src/main/java/org/queryall/api/utils/WebappConfig.java
@@ -283,6 +283,14 @@ public enum WebappConfig
      */
     REDIRECT_TO_EXPLICIT_FORMAT_HTTP_CODE("redirectToExplicitFormatHttpCode", 303),
     
+    RESULTS_PAGE_SCRIPTS("resultsPageScripts", Collections.emptyList()),
+    
+    RESULTS_PAGE_SCRIPTS_LOCAL("resultsPageScriptsLocal", Collections.emptyList()),
+    
+    RESULTS_PAGE_STYLESHEETS("resultsPageStylesheets", Collections.emptyList()),
+    
+    RESULTS_PAGE_STYLESHEETS_LOCAL("resultsPageStylesheetsLocal", Collections.emptyList()),
+    
     RESULTS_TEMPLATE("resultsTemplate", "page.vm"),
     
     ROBOT_HELP_URL("robotHelpUrl", "https://sourceforge.net/apps/mediawiki/bio2rdf/index.php?title=RobotHelp"),

--- a/queryall-api/src/test/java/org/queryall/api/utils/test/WebappConfigTest.java
+++ b/queryall-api/src/test/java/org/queryall/api/utils/test/WebappConfigTest.java
@@ -23,7 +23,7 @@ public class WebappConfigTest
     /**
      * NOTE: This property needs to be updated if any new properties are added
      */
-    private static final int EXPECTED_CONFIG_SIZE = 114;
+    private static final int EXPECTED_CONFIG_SIZE = 118;
     
     private ValueFactory testValueFactory;
     

--- a/queryall-content-negotiation/pom.xml
+++ b/queryall-content-negotiation/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-content-negotiation</artifactId>
@@ -17,7 +17,7 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/queryall-content-negotiation/pom.xml
+++ b/queryall-content-negotiation/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-content-negotiation</artifactId>
 	<name>queryall-content-negotiation</name>
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/queryall-ext-provider-http/pom.xml
+++ b/queryall-ext-provider-http/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-provider-http</artifactId>
@@ -31,21 +31,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-provider-http/pom.xml
+++ b/queryall-ext-provider-http/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-provider-http</artifactId>
 	<name>queryall-ext-provider-http</name>
@@ -33,21 +33,21 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-provider-rdf/pom.xml
+++ b/queryall-ext-provider-rdf/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-provider-rdf</artifactId>
 	<name>queryall-ext-provider-rdf</name>
@@ -33,28 +33,28 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-provider-http</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-provider-rdf/pom.xml
+++ b/queryall-ext-provider-rdf/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-provider-rdf</artifactId>
@@ -31,28 +31,28 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-provider-http</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-querytype-rdf/pom.xml
+++ b/queryall-ext-querytype-rdf/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-querytype-rdf</artifactId>
 	<name>queryall-ext-querytype-rdf</name>
@@ -33,21 +33,21 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-querytype-rdf/pom.xml
+++ b/queryall-ext-querytype-rdf/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-querytype-rdf</artifactId>
@@ -31,21 +31,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-querytype-regex/pom.xml
+++ b/queryall-ext-querytype-regex/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-querytype-regex</artifactId>
 	<name>queryall-ext-querytype-regex</name>
@@ -33,21 +33,21 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-querytype-regex/pom.xml
+++ b/queryall-ext-querytype-regex/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-querytype-regex</artifactId>
@@ -31,21 +31,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-rule-owl/pom.xml
+++ b/queryall-ext-rule-owl/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/queryall-ext-rule-owl/pom.xml
+++ b/queryall-ext-rule-owl/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.2-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-owl</artifactId>
@@ -27,7 +27,7 @@
 			<version>2.3.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/queryall-ext-rule-prefixmap/pom.xml
+++ b/queryall-ext-rule-prefixmap/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-prefixmap</artifactId>
@@ -31,21 +31,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-rule-prefixmap/pom.xml
+++ b/queryall-ext-rule-prefixmap/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-prefixmap</artifactId>
 	<name>queryall-ext-rule-prefixmap</name>
@@ -33,21 +33,21 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-rule-regex/pom.xml
+++ b/queryall-ext-rule-regex/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-regex</artifactId>
@@ -31,21 +31,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-rule-regex/pom.xml
+++ b/queryall-ext-rule-regex/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-regex</artifactId>
 	<name>queryall-ext-rule-regex</name>
@@ -33,21 +33,21 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-rule-sparql/pom.xml
+++ b/queryall-ext-rule-sparql/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-sparql</artifactId>
 	<name>queryall-ext-rule-sparql</name>
@@ -33,21 +33,21 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-rule-sparql/pom.xml
+++ b/queryall-ext-rule-sparql/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-sparql</artifactId>
@@ -31,21 +31,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-rule-spin/pom.xml
+++ b/queryall-ext-rule-spin/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-spin</artifactId>
@@ -41,17 +41,17 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-ext-rule-spin/pom.xml
+++ b/queryall-ext-rule-spin/pom.xml
@@ -43,17 +43,17 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-rule-xslt/pom.xml
+++ b/queryall-ext-rule-xslt/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-xslt</artifactId>
 	<name>queryall-ext-rule-xslt</name>
@@ -33,21 +33,21 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>

--- a/queryall-ext-rule-xslt/pom.xml
+++ b/queryall-ext-rule-xslt/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-ext-rule-xslt</artifactId>
@@ -31,21 +31,21 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>

--- a/queryall-lib-test/pom.xml
+++ b/queryall-lib-test/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>queryall-parent</artifactId>
 		<groupId>org.queryall</groupId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-lib-test</artifactId>
 	<name>queryall-lib-test</name>
@@ -16,69 +16,69 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-rule-xslt</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-rule-sparql</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-rule-regex</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-rule-prefixmap</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-provider-http</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-provider-rdf</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-querytype-rdf</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-ext-querytype-regex</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/queryall-lib-test/pom.xml
+++ b/queryall-lib-test/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<artifactId>queryall-parent</artifactId>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<version>1.3.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>queryall-lib-test</artifactId>
@@ -14,69 +14,69 @@
 	<inceptionYear>2011</inceptionYear>
 	<dependencies>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 			<type>jar</type>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-rule-xslt</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-rule-sparql</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-rule-regex</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-rule-prefixmap</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-provider-http</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-provider-rdf</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-querytype-rdf</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-ext-querytype-regex</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/queryall-lib-test/src/test/java/org/queryall/utils/test/ProviderUtilsTest.java
+++ b/queryall-lib-test/src/test/java/org/queryall/utils/test/ProviderUtilsTest.java
@@ -665,7 +665,7 @@ public class ProviderUtilsTest
     
     /**
      * Test method for
-     * {@link org.queryall.utils.ProviderUtils#getProvidersForQueryType(java.util.Map, org.openrdf.model.URI)}
+     * {@link org.queryall.utils.ProviderUtils#getProvidersSupportingQueryType(java.util.Map, org.openrdf.model.URI)}
      * .
      */
     @Test
@@ -685,12 +685,12 @@ public class ProviderUtilsTest
             Assert.assertEquals(1, testProviders.size());
             
             final Map<URI, Provider> trueResults =
-                    ProviderUtils.getProvidersForQueryType(testProviders, this.testQueryUri1);
+                    ProviderUtils.getProvidersSupportingQueryType(testProviders, this.testQueryUri1);
             
             Assert.assertEquals(1, trueResults.size());
             
             final Map<URI, Provider> falseResults =
-                    ProviderUtils.getProvidersForQueryType(testProviders, this.testQueryUri2);
+                    ProviderUtils.getProvidersSupportingQueryType(testProviders, this.testQueryUri2);
             
             Assert.assertEquals(0, falseResults.size());
             

--- a/queryall-lib-test/src/test/java/org/queryall/utils/test/QueryTypeUtilsTest.java
+++ b/queryall-lib-test/src/test/java/org/queryall/utils/test/QueryTypeUtilsTest.java
@@ -140,7 +140,7 @@ public class QueryTypeUtilsTest
      * .
      */
     @Test
-    public void testGetQueryTypesMatchingQuery()
+    public void testGetQueryTypesMatchingQueryPreferred()
     {
         final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryPreferred =
                 QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawPreferredConverted,
@@ -155,7 +155,16 @@ public class QueryTypeUtilsTest
         
         Assert.assertEquals("preferred namespaces result did not have a parameter to namespace map attached to it", 1,
                 queryTypesMatchingQueryPreferred.get(this.testRegexInputQueryType1).size());
-        
+    }
+    
+    /**
+     * Test method for
+     * {@link org.queryall.utils.QueryTypeUtils#getQueryTypesMatchingQuery(java.util.Map, java.util.List, java.util.Map, java.util.Map, java.util.Map, boolean, boolean)}
+     * .
+     */
+    @Test
+    public void testGetQueryTypesMatchingQueryAlternate()
+    {
         final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryAlternate =
                 QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawAlternateConverted,
                         new ArrayList<Profile>(0), this.testAllQueryTypes, this.testNamespacePrefixMap,
@@ -169,7 +178,16 @@ public class QueryTypeUtilsTest
         
         Assert.assertEquals("alternate namespaces result did not have a parameter to namespace map attached to it", 1,
                 queryTypesMatchingQueryAlternate.get(this.testRegexInputQueryType1).size());
-        
+    }
+    
+    /**
+     * Test method for
+     * {@link org.queryall.utils.QueryTypeUtils#getQueryTypesMatchingQuery(java.util.Map, java.util.List, java.util.Map, java.util.Map, java.util.Map, boolean, boolean)}
+     * .
+     */
+    @Test
+    public void testGetQueryTypesMatchingQueryUnconvertedPreferred()
+    {
         final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryUnconvertedPreferred =
                 QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawPreferredConverted,
                         new ArrayList<Profile>(0), this.testAllQueryTypes, this.testNamespacePrefixMap,
@@ -183,7 +201,16 @@ public class QueryTypeUtilsTest
         
         Assert.assertEquals("preferred namespaces result did not have a parameter to namespace map attached to it", 1,
                 queryTypesMatchingQueryUnconvertedPreferred.get(this.testRegexInputQueryType1).size());
-        
+    }
+    
+    /**
+     * Test method for
+     * {@link org.queryall.utils.QueryTypeUtils#getQueryTypesMatchingQuery(java.util.Map, java.util.List, java.util.Map, java.util.Map, java.util.Map, boolean, boolean)}
+     * .
+     */
+    @Test
+    public void testGetQueryTypesMatchingQueryUnconvertedAlternate()
+    {
         final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryUnconvertedAlternate =
                 QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawAlternateConverted,
                         new ArrayList<Profile>(0), this.testAllQueryTypes, this.testNamespacePrefixMap,
@@ -197,19 +224,22 @@ public class QueryTypeUtilsTest
         
         Assert.assertEquals("alternate namespaces result did not have a parameter to namespace map attached to it", 1,
                 queryTypesMatchingQueryUnconvertedAlternate.get(this.testRegexInputQueryType1).size());
-        
+    }
+    
+    /**
+     * Test method for
+     * {@link org.queryall.utils.QueryTypeUtils#getQueryTypesMatchingQuery(java.util.Map, java.util.List, java.util.Map, java.util.Map, java.util.Map, boolean, boolean)}
+     * .
+     */
+    @Test
+    public void testGetQueryTypesMatchingQueryFalse()
+    {
         final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryFalse =
                 QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawFalse, new ArrayList<Profile>(0),
                         this.testAllQueryTypes, this.testNamespacePrefixMap, this.testAllNamespaceEntries, true, true);
         
-        Assert.assertEquals("false namespaces did not generated a single result", 1,
+        Assert.assertEquals("false namespaces did not generated an empty result", 0,
                 queryTypesMatchingQueryFalse.size());
-        
-        Assert.assertTrue("Query type was not in the false namespaces results set",
-                queryTypesMatchingQueryFalse.containsKey(this.testRegexInputQueryType1));
-        
-        Assert.assertEquals("false namespaces result had a parameter to namespace map attached to it", 0,
-                queryTypesMatchingQueryFalse.get(this.testRegexInputQueryType1).size());
     }
     
     /**

--- a/queryall-lib-test/src/test/java/org/queryall/utils/test/QueryTypeUtilsTest.java
+++ b/queryall-lib-test/src/test/java/org/queryall/utils/test/QueryTypeUtilsTest.java
@@ -140,29 +140,6 @@ public class QueryTypeUtilsTest
      * .
      */
     @Test
-    public void testGetQueryTypesMatchingQueryPreferred()
-    {
-        final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryPreferred =
-                QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawPreferredConverted,
-                        new ArrayList<Profile>(0), this.testAllQueryTypes, this.testNamespacePrefixMap,
-                        this.testAllNamespaceEntries, true, true);
-        
-        Assert.assertEquals("preferred namespaces did not generate a single result", 1,
-                queryTypesMatchingQueryPreferred.size());
-        
-        Assert.assertTrue("Query type was not in the preferred namespaces results set",
-                queryTypesMatchingQueryPreferred.containsKey(this.testRegexInputQueryType1));
-        
-        Assert.assertEquals("preferred namespaces result did not have a parameter to namespace map attached to it", 1,
-                queryTypesMatchingQueryPreferred.get(this.testRegexInputQueryType1).size());
-    }
-    
-    /**
-     * Test method for
-     * {@link org.queryall.utils.QueryTypeUtils#getQueryTypesMatchingQuery(java.util.Map, java.util.List, java.util.Map, java.util.Map, java.util.Map, boolean, boolean)}
-     * .
-     */
-    @Test
     public void testGetQueryTypesMatchingQueryAlternate()
     {
         final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryAlternate =
@@ -186,21 +163,37 @@ public class QueryTypeUtilsTest
      * .
      */
     @Test
-    public void testGetQueryTypesMatchingQueryUnconvertedPreferred()
+    public void testGetQueryTypesMatchingQueryFalse()
     {
-        final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryUnconvertedPreferred =
+        final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryFalse =
+                QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawFalse, new ArrayList<Profile>(0),
+                        this.testAllQueryTypes, this.testNamespacePrefixMap, this.testAllNamespaceEntries, true, true);
+        
+        Assert.assertEquals("false namespaces did not generated an empty result", 0,
+                queryTypesMatchingQueryFalse.size());
+    }
+    
+    /**
+     * Test method for
+     * {@link org.queryall.utils.QueryTypeUtils#getQueryTypesMatchingQuery(java.util.Map, java.util.List, java.util.Map, java.util.Map, java.util.Map, boolean, boolean)}
+     * .
+     */
+    @Test
+    public void testGetQueryTypesMatchingQueryPreferred()
+    {
+        final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryPreferred =
                 QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawPreferredConverted,
                         new ArrayList<Profile>(0), this.testAllQueryTypes, this.testNamespacePrefixMap,
                         this.testAllNamespaceEntries, true, true);
         
         Assert.assertEquals("preferred namespaces did not generate a single result", 1,
-                queryTypesMatchingQueryUnconvertedPreferred.size());
+                queryTypesMatchingQueryPreferred.size());
         
         Assert.assertTrue("Query type was not in the preferred namespaces results set",
-                queryTypesMatchingQueryUnconvertedPreferred.containsKey(this.testRegexInputQueryType1));
+                queryTypesMatchingQueryPreferred.containsKey(this.testRegexInputQueryType1));
         
         Assert.assertEquals("preferred namespaces result did not have a parameter to namespace map attached to it", 1,
-                queryTypesMatchingQueryUnconvertedPreferred.get(this.testRegexInputQueryType1).size());
+                queryTypesMatchingQueryPreferred.get(this.testRegexInputQueryType1).size());
     }
     
     /**
@@ -232,14 +225,21 @@ public class QueryTypeUtilsTest
      * .
      */
     @Test
-    public void testGetQueryTypesMatchingQueryFalse()
+    public void testGetQueryTypesMatchingQueryUnconvertedPreferred()
     {
-        final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryFalse =
-                QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawFalse, new ArrayList<Profile>(0),
-                        this.testAllQueryTypes, this.testNamespacePrefixMap, this.testAllNamespaceEntries, true, true);
+        final Map<QueryType, Map<String, Collection<NamespaceEntry>>> queryTypesMatchingQueryUnconvertedPreferred =
+                QueryTypeUtils.getQueryTypesMatchingQuery(this.testParametersRawPreferredConverted,
+                        new ArrayList<Profile>(0), this.testAllQueryTypes, this.testNamespacePrefixMap,
+                        this.testAllNamespaceEntries, true, true);
         
-        Assert.assertEquals("false namespaces did not generated an empty result", 0,
-                queryTypesMatchingQueryFalse.size());
+        Assert.assertEquals("preferred namespaces did not generate a single result", 1,
+                queryTypesMatchingQueryUnconvertedPreferred.size());
+        
+        Assert.assertTrue("Query type was not in the preferred namespaces results set",
+                queryTypesMatchingQueryUnconvertedPreferred.containsKey(this.testRegexInputQueryType1));
+        
+        Assert.assertEquals("preferred namespaces result did not have a parameter to namespace map attached to it", 1,
+                queryTypesMatchingQueryUnconvertedPreferred.get(this.testRegexInputQueryType1).size());
     }
     
     /**

--- a/queryall-lib/pom.xml
+++ b/queryall-lib/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<artifactId>queryall-parent</artifactId>
 		<version>1.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
@@ -13,7 +13,7 @@
 	<name>queryall lib</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/queryall-lib/pom.xml
+++ b/queryall-lib/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.queryall</groupId>
 		<artifactId>queryall-parent</artifactId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
@@ -15,7 +15,7 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.openrdf.sesame</groupId>

--- a/queryall-lib/src/main/java/org/queryall/comparators/ContextInsensitiveStatementComparator.java
+++ b/queryall-lib/src/main/java/org/queryall/comparators/ContextInsensitiveStatementComparator.java
@@ -1,0 +1,52 @@
+package org.queryall.comparators;
+
+import java.util.Comparator;
+
+import org.openrdf.model.Statement;
+
+/**
+ * Implements a Comparator for OpenRDF Statements using the order Subject->Predicate->Object
+ * 
+ * @author Peter Ansell p_ansell@yahoo.com
+ */
+public class ContextInsensitiveStatementComparator implements Comparator<Statement>
+{
+    public final static int BEFORE = -1;
+    public final static int EQUALS = 0;
+    public final static int AFTER = 1;
+    
+    @Override
+    public int compare(final Statement first, final Statement second)
+    {
+        // Cannot use Statement.equals as it does not take Context into account,
+        // but can check for reference equality (==)
+        if(first == second)
+        {
+            return ContextInsensitiveStatementComparator.EQUALS;
+        }
+        
+        if(first.getSubject().equals(second.getSubject()))
+        {
+            if(first.getPredicate().equals(second.getPredicate()))
+            {
+                if(first.getObject().equals(second.getObject()))
+                {
+                    return ContextInsensitiveStatementComparator.EQUALS;
+                }
+                else
+                {
+                    return new ValueComparator().compare(first.getObject(), second.getObject());
+                }
+            }
+            else
+            {
+                return new ValueComparator().compare(first.getPredicate(), second.getPredicate());
+            }
+        }
+        else
+        {
+            return new ValueComparator().compare(first.getSubject(), second.getSubject());
+        }
+    }
+    
+}

--- a/queryall-lib/src/main/java/org/queryall/impl/profile/ProfileImpl.java
+++ b/queryall-lib/src/main/java/org/queryall/impl/profile/ProfileImpl.java
@@ -260,11 +260,6 @@ public class ProfileImpl extends BaseQueryAllImpl implements Profile, Comparable
         return this.getKey().stringValue().compareTo(otherProfile.getKey().stringValue());
     }
     
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(final Object obj)
     {

--- a/queryall-lib/src/main/java/org/queryall/query/QueryBundle.java
+++ b/queryall-lib/src/main/java/org/queryall/query/QueryBundle.java
@@ -33,12 +33,13 @@ import org.slf4j.LoggerFactory;
 public class QueryBundle
 {
     private static final Logger log = LoggerFactory.getLogger(QueryBundle.class);
+    
     @SuppressWarnings("unused")
     private static final boolean TRACE = QueryBundle.log.isTraceEnabled();
+    
     @SuppressWarnings("unused")
     private static final boolean DEBUG = QueryBundle.log.isDebugEnabled();
     private static final boolean INFO = QueryBundle.log.isInfoEnabled();
-    
     // This query is specifically tailored for the provider with respect to the URI
     // (de)normalisation rules
     // private String query = "";
@@ -49,17 +50,18 @@ public class QueryBundle
     // private String queryEndpoint = "";
     // The following is the unreplaced endpoint String
     // private String originalEndpointString = "";
-    
     private Provider originalProvider;
-    private QueryType customQueryType;
-    private boolean redirectRequired = false;
     
+    private QueryType customQueryType;
+    
+    private boolean redirectRequired = false;
     private List<Profile> relevantProfiles = new ArrayList<Profile>();
     private Map<String, String> alternativeEndpointsAndQueries = new HashMap<String, String>();
-    private QueryAllConfiguration localSettings;
     
+    private QueryAllConfiguration localSettings;
     public static URI queryBundleTypeUri;
     public static URI queryLiteralUri;
+    
     public static URI queryBundleEndpointUriTerm;
     public static URI queryBundleOriginalEndpointStringTerm;
     public static URI queryBundleAlternativeEndpointUriTerm;
@@ -68,7 +70,6 @@ public class QueryBundle
     public static URI queryBundleProviderUri;
     public static URI queryBundleProfileUri;
     public static URI queryBundleConfigurationApiVersion;
-    
     static
     {
         final ValueFactory f = Constants.VALUE_FACTORY;
@@ -167,6 +168,89 @@ public class QueryBundle
         
     }
     
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(final Object obj)
+    {
+        if(this == obj)
+        {
+            return true;
+        }
+        if(obj == null)
+        {
+            return false;
+        }
+        if(!(obj instanceof QueryBundle))
+        {
+            return false;
+        }
+        final QueryBundle other = (QueryBundle)obj;
+        if(this.alternativeEndpointsAndQueries == null)
+        {
+            if(other.alternativeEndpointsAndQueries != null)
+            {
+                return false;
+            }
+        }
+        else if(!this.alternativeEndpointsAndQueries.equals(other.alternativeEndpointsAndQueries))
+        {
+            return false;
+        }
+        if(this.customQueryType == null)
+        {
+            if(other.customQueryType != null)
+            {
+                return false;
+            }
+        }
+        else if(!this.customQueryType.equals(other.customQueryType))
+        {
+            return false;
+        }
+        if(this.originalProvider == null)
+        {
+            if(other.originalProvider != null)
+            {
+                return false;
+            }
+        }
+        else if(!this.originalProvider.equals(other.originalProvider))
+        {
+            return false;
+        }
+        if(this.redirectRequired != other.redirectRequired)
+        {
+            return false;
+        }
+        if(this.relevantProfiles == null)
+        {
+            if(other.relevantProfiles != null)
+            {
+                return false;
+            }
+        }
+        else if(!this.relevantProfiles.equals(other.relevantProfiles))
+        {
+            return false;
+        }
+        if(this.staticRdfXmlString == null)
+        {
+            if(other.staticRdfXmlString != null)
+            {
+                return false;
+            }
+        }
+        else if(!this.staticRdfXmlString.equals(other.staticRdfXmlString))
+        {
+            return false;
+        }
+        return true;
+    }
+    
     /**
      * Get an unmodifiable Map containing alternative endpoints as keys and queries as values
      * 
@@ -222,6 +306,29 @@ public class QueryBundle
     public String getStaticRdfXmlString()
     {
         return this.staticRdfXmlString;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result =
+                prime
+                        * result
+                        + ((this.alternativeEndpointsAndQueries == null) ? 0 : this.alternativeEndpointsAndQueries
+                                .hashCode());
+        result = prime * result + ((this.customQueryType == null) ? 0 : this.customQueryType.hashCode());
+        result = prime * result + ((this.originalProvider == null) ? 0 : this.originalProvider.hashCode());
+        result = prime * result + (this.redirectRequired ? 1231 : 1237);
+        result = prime * result + ((this.relevantProfiles == null) ? 0 : this.relevantProfiles.hashCode());
+        result = prime * result + ((this.staticRdfXmlString == null) ? 0 : this.staticRdfXmlString.hashCode());
+        return result;
     }
     
     /**
@@ -425,7 +532,7 @@ public class QueryBundle
         
         // sb.append("queryEndpoint=" + this.getQueryEndpoint() + "\n");
         // sb.append("query=" + this.getQuery() + "\n");
-        // sb.append("staticRdfXmlString=" + this.getStaticRdfXmlString() + "\n");
+        sb.append("staticRdfXmlString=" + this.getStaticRdfXmlString() + "\n");
         
         if(this.getProvider() == null)
         {

--- a/queryall-lib/src/main/java/org/queryall/utils/ListUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/ListUtils.java
@@ -122,12 +122,12 @@ public class ListUtils
     public static boolean collectionContainsStringIgnoreCase(final Collection<String> stringCollection,
             String searchString)
     {
-        searchString = searchString.toLowerCase(Locale.ENGLISH);
-        
         if(stringCollection == null)
         {
             return false;
         }
+        
+        searchString = searchString.toLowerCase(Locale.ENGLISH);
         
         for(final String nextString : stringCollection)
         {

--- a/queryall-lib/src/main/java/org/queryall/utils/NamespaceUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/NamespaceUtils.java
@@ -15,6 +15,14 @@ import org.openrdf.model.URI;
 public class NamespaceUtils
 {
     
+    /**
+     * Gets the entry on the given map based on the given namespaceprefix, returning the empty list
+     * if it is not available, and a wrapped unmodifiable collection otherwise.
+     * 
+     * @param allNamespacesByPrefix
+     * @param namespacePrefix
+     * @return
+     */
     public static Collection<URI> getNamespaceUrisForPrefix(final Map<String, Collection<URI>> allNamespacesByPrefix,
             final String namespacePrefix)
     {

--- a/queryall-lib/src/main/java/org/queryall/utils/ProfileUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/ProfileUtils.java
@@ -26,6 +26,18 @@ public class ProfileUtils
     private static final boolean DEBUG = ProfileUtils.log.isDebugEnabled();
     private static final boolean INFO = ProfileUtils.log.isInfoEnabled();
     
+    /**
+     * Fetches the profiles in the collection specified by nextProfileUriList from the map given as
+     * allProfiles and then sorts them based on nextSortOrder.
+     * 
+     * Sorting is performed based on the fact that all Profile implementations are required to
+     * implement Comparable<Profile>.
+     * 
+     * @param nextProfileUriList
+     * @param nextSortOrder
+     * @param allProfiles
+     * @return
+     */
     public static List<Profile> getAndSortProfileList(final Collection<URI> nextProfileUriList,
             final SortOrder nextSortOrder, final Map<URI, Profile> allProfiles)
     {
@@ -61,6 +73,7 @@ public class ProfileUtils
         {
             throw new RuntimeException("getAndSortProfileList: sortOrder unrecognised nextSortOrder=" + nextSortOrder);
         }
+        
         return results;
     }
 }

--- a/queryall-lib/src/main/java/org/queryall/utils/ProviderUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/ProviderUtils.java
@@ -75,12 +75,24 @@ public final class ProviderUtils
     }
     
     /**
+     * Finds all of the providers in the given list that could be applicable to the given
+     * namespaces.
      * 
+     * Default providers are not returned by this method if they do not also contain matching
+     * namespaces.
      * 
      * @param allProviders
+     *            A map of providers based on their URIs to iterate over to find matching providers.
+     *            Typically this will be a list of providers that are known to support a particular
+     *            query type.
      * @param namespaceUris
+     *            A map of the input tag names to namespace URIs that may match with the value of
+     *            the tag name.
      * @param namespaceMatchMethod
-     * @return
+     *            The match method defined in the NamespaceMatch enum that will be used for this
+     *            method. This was defined in the query type that is being used above this method.
+     * @return A map of URIs to Providers that matched the given namespace tag and URI combinations
+     *         using the given NamespaceMatch method.
      */
     public static Map<URI, Provider> getProvidersForNamespaceUris(final Map<URI, Provider> allProviders,
             final Map<String, Collection<URI>> namespaceUris, final NamespaceMatch namespaceMatchMethod)
@@ -97,6 +109,11 @@ public final class ProviderUtils
             // Assume nothing found for anyFound so we can switch it if anything is found
             boolean anyFound = false;
             // Assume everything found for allFound so we can switch it if anything is not found
+            // FIXME: We assume that we will always go through the for loop below at least once, per
+            // the check on namespaceUris.size() above, but we do not take into account the continue
+            // instruction
+            // In some rare cases nextNamespaceUriList will always be null, and the loop will always
+            // short-circuit.
             boolean allFound = true;
             
             for(final String nextInputParameter : namespaceUris.keySet())

--- a/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
@@ -69,6 +69,8 @@ public class QueryBundleUtils
             final boolean convertAlternateToPreferred, final boolean recogniseImplicitRdfruleInclusions,
             final boolean includeNonProfileMatchedRdfrules) throws QueryAllException
     {
+        // NOTE: Important that this is a HashSet, and that QueryBundle implements hashCode and
+        // equals to avoid duplicates
         final Collection<QueryBundle> results = new HashSet<QueryBundle>();
         
         // Note: We default to converting alternate namespaces to preferred unless it is turned off

--- a/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
@@ -78,13 +78,20 @@ public class QueryBundleUtils
         
         for(final Provider nextProvider : chosenProviders)
         {
-            QueryBundleUtils.log.info("start of loop body for nextProvider=" + nextProvider.getKey().stringValue());
+            if(QueryBundleUtils.DEBUG)
+            {
+                QueryBundleUtils.log.debug("start of loop body for nextProvider={}", nextProvider.getKey()
+                        .stringValue());
+            }
             final boolean noCommunicationProvider =
                     nextProvider.getEndpointMethod().equals(ProviderSchema.getProviderNoCommunication());
             
             if(nextProvider instanceof HttpProvider)
             {
-                QueryBundleUtils.log.info("nextProvider instanceof HttpProvider");
+                if(QueryBundleUtils.DEBUG)
+                {
+                    QueryBundleUtils.log.debug("nextProvider instanceof HttpProvider");
+                }
                 final HttpProvider nextHttpProvider = (HttpProvider)nextProvider;
                 // FIXME: attributeList should not be shared in this way. It will use the last (ie,
                 // random) endpoint for the static inclusions right now, which doesn't seem right.
@@ -218,12 +225,18 @@ public class QueryBundleUtils
             } // end if(nextProvider instanceof HttpProvider)
             else if(noCommunicationProvider)
             {
-                QueryBundleUtils.log.info("noCommunicationProvider == true");
+                if(QueryBundleUtils.DEBUG)
+                {
+                    QueryBundleUtils.log.debug("noCommunicationProvider == true");
+                }
                 final StringBuilder nextStaticRdfXmlString = new StringBuilder();
                 
                 for(final URI nextCustomInclude : nextQueryType.getLinkedQueryTypes())
                 {
-                    QueryBundleUtils.log.info("d");
+                    if(QueryBundleUtils.TRACE)
+                    {
+                        QueryBundleUtils.log.trace("d");
+                    }
                     // pick out all of the QueryType's which have been delegated for this particular
                     // query as static includes
                     final QueryType nextCustomIncludeType = allQueryTypes.get(nextCustomInclude);
@@ -258,7 +271,10 @@ public class QueryBundleUtils
                 results.add(nextProviderQueryBundle);
             }
             
-            QueryBundleUtils.log.info("end of loop body for nextProvider=" + nextProvider.getKey().stringValue());
+            if(QueryBundleUtils.DEBUG)
+            {
+                QueryBundleUtils.log.debug("end of loop body for nextProvider={}", nextProvider.getKey().stringValue());
+            }
         } // end for(Provider nextProvider : QueryTypeProviders)
         
         return results;

--- a/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
@@ -1,8 +1,8 @@
 package org.queryall.utils;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -69,7 +69,7 @@ public class QueryBundleUtils
             final boolean convertAlternateToPreferred, final boolean recogniseImplicitRdfruleInclusions,
             final boolean includeNonProfileMatchedRdfrules) throws QueryAllException
     {
-        final Collection<QueryBundle> results = new ArrayList<QueryBundle>();
+        final Collection<QueryBundle> results = new HashSet<QueryBundle>();
         
         // Note: We default to converting alternate namespaces to preferred unless it is turned off
         // in the configuration. It can always be turned off for each namespace entry individually

--- a/queryall-lib/src/main/java/org/queryall/utils/QueryTypeUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/QueryTypeUtils.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import org.openrdf.model.URI;
 import org.queryall.api.namespace.NamespaceEntry;
+import org.queryall.api.namespace.ValidatingNamespaceEntry;
 import org.queryall.api.profile.Profile;
 import org.queryall.api.querytype.InputQueryType;
 import org.queryall.api.querytype.QueryType;
@@ -97,7 +98,16 @@ public final class QueryTypeUtils
                             
                             for(final URI nextNamespaceUri : namespaceMatches.get(nextParameter))
                             {
-                                namespaceParameterMatches.add(allNamespaceEntries.get(nextNamespaceUri));
+                                final NamespaceEntry nextNamespaceEntry = allNamespaceEntries.get(nextNamespaceUri);
+                                
+                                if(nextNamespaceEntry instanceof ValidatingNamespaceEntry)
+                                {
+                                    // TODO: implement validation code here on the queryParameter
+                                    // that is identified as the "identifier" for this namespace in
+                                    // the context of this query
+                                }
+                                
+                                namespaceParameterMatches.add(nextNamespaceEntry);
                             }
                             
                             actualNamespaceEntries.put(nextParameter, namespaceParameterMatches);

--- a/queryall-lib/src/main/java/org/queryall/utils/QueryTypeUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/QueryTypeUtils.java
@@ -79,8 +79,6 @@ public final class QueryTypeUtils
                                 + nextQuery.getKey().stringValue() + " queryParameters=" + queryParameters);
                     }
                     
-                    Map<String, Collection<NamespaceEntry>> actualNamespaceEntries;
-                    
                     // Only try to populate actualNamespaceEntries if the query is namespace
                     // specific
                     if(nextQuery.getIsNamespaceSpecific())
@@ -89,7 +87,7 @@ public final class QueryTypeUtils
                                 QueryTypeUtils.namespacesMatchesForQueryParameters(nextInputQuery, queryParameters,
                                         namespacePrefixesToUris);
                         
-                        actualNamespaceEntries =
+                        final Map<String, Collection<NamespaceEntry>> actualNamespaceEntries =
                                 new HashMap<String, Collection<NamespaceEntry>>(namespaceMatches.size() * 2);
                         
                         for(final String nextParameter : namespaceMatches.keySet())
@@ -104,19 +102,31 @@ public final class QueryTypeUtils
                             
                             actualNamespaceEntries.put(nextParameter, namespaceParameterMatches);
                         }
+                        
+                        if(actualNamespaceEntries.size() > 0)
+                        {
+                            results.put(nextQuery, actualNamespaceEntries);
+                        }
+                        else if(QueryTypeUtils.INFO)
+                        {
+                            QueryTypeUtils.log
+                                    .info("No namespace parameters matched for a namespace specific query, so not including this query type nextQuery={}",
+                                            nextQuery.getKey().stringValue());
+                        }
                     }
                     else
                     {
                         if(QueryTypeUtils.DEBUG)
                         {
                             QueryTypeUtils.log
-                                    .debug("query type is not namespace specific, creating an empty namespace parameter map");
+                                    .debug("Query type is not namespace specific, creating an empty namespace parameter map");
                         }
                         // In other cases use an unmodifiable empty map
-                        actualNamespaceEntries = Collections.emptyMap();
+                        final Map<String, Collection<NamespaceEntry>> emptyMap = Collections.emptyMap();
+                        
+                        results.put(nextQuery, emptyMap);
                     }
                     
-                    results.put(nextQuery, actualNamespaceEntries);
                 }
                 else if(QueryTypeUtils.TRACE)
                 {

--- a/queryall-lib/src/main/java/org/queryall/utils/RdfUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/RdfUtils.java
@@ -2854,6 +2854,7 @@ public final class RdfUtils
                         + nextResult.getReturnedContentType() + " nextReaderFormat=" + nextReaderFormat);
             }
             
+            // TODO: Integrate the Any23 methods here if a fallback is needed
             if(nextReaderFormat == null)
             {
                 String assumedContentType = null;
@@ -2871,7 +2872,7 @@ public final class RdfUtils
                 
                 // HACK: Do not try to parse text/html, as it results in meaningless triples that
                 // are confusing
-                if(nextReaderFormat == null && !assumedContentType.equals(Constants.TEXT_HTML))
+                if(nextReaderFormat == null && !Constants.TEXT_HTML.equals(nextResult.getReturnedMIMEType()))
                 {
                     nextReaderFormat = Rio.getParserFormatForMIMEType(defaultAssumedResponseContentType);
                 }

--- a/queryall-lib/src/main/java/org/queryall/utils/RdfUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/RdfUtils.java
@@ -2869,7 +2869,9 @@ public final class RdfUtils
                     nextReaderFormat = Rio.getParserFormatForMIMEType(assumedContentType);
                 }
                 
-                if(nextReaderFormat == null)
+                // HACK: Do not try to parse text/html, as it results in meaningless triples that
+                // are confusing
+                if(nextReaderFormat == null && !assumedContentType.equals(Constants.TEXT_HTML))
                 {
                     nextReaderFormat = Rio.getParserFormatForMIMEType(defaultAssumedResponseContentType);
                 }
@@ -2881,7 +2883,7 @@ public final class RdfUtils
                                     + nextResult.getReturnedMIMEType()
                                     + " nextResult.assumedContentType="
                                     + assumedContentType
-                                    + " Settings.getStringPropertyFromConfig(\"assumedResponseContentType\")="
+                                    + " defaultAssumedResponseContentType="
                                     + defaultAssumedResponseContentType);
                     // throw new
                     // RuntimeException("Utilities: Not attempting to parse because there are no content types to use for interpretation");
@@ -2929,7 +2931,8 @@ public final class RdfUtils
             }
             else
             {
-                RdfUtils.log.warn("Not adding anything for next result as the result was empty");
+                RdfUtils.log
+                        .warn("Not adding anything for next result as the result was empty or the format was not understood");
             }
             
             if(RdfUtils.DEBUG)

--- a/queryall-lib/src/main/java/org/queryall/utils/StringUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/StringUtils.java
@@ -48,9 +48,11 @@ public class StringUtils
                 localSettings.getStringProperty(WebappConfig.PLAIN_NAMESPACE_AND_IDENTIFIER_REGEX), nsAndId);
     }
     
-    public static Map<String, List<String>> getNamespaceAndIdentifierFromUri(final String nextUri,
+    @SuppressWarnings("unused")
+    private static Map<String, List<String>> getNamespaceAndIdentifierFromUri(final String nextUri,
             final QueryAllConfiguration localSettings)
     {
+        // FIXME: Should be attempting to match against the template in a namespace entry
         if(nextUri.startsWith(localSettings.getDefaultHostAddress()))
         {
             return StringUtils.getNamespaceAndIdentifier(
@@ -143,6 +145,8 @@ public class StringUtils
                 matches.add(matcher.group(i + 1));
                 
                 // TODO: is there any way we can make this cleaner?
+                // input_NN here is the convention that was used for the regex matches before the
+                // new string based method, so it is used here to provide backwards compatibility
                 results.put("input_" + (i + 1), matches);
                 
                 found = true;

--- a/queryall-webapp/pom.xml
+++ b/queryall-webapp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.queryall</groupId>
 		<artifactId>queryall-parent</artifactId>
-		<version>1.3</version>
+		<version>1.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
@@ -15,17 +15,17 @@
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.queryall</groupId>
 			<artifactId>queryall-content-negotiation</artifactId>
-			<version>${queryall.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/queryall-webapp/pom.xml
+++ b/queryall-webapp/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
-		<groupId>org.queryall</groupId>
+		<groupId>com.github.queryall</groupId>
 		<artifactId>queryall-parent</artifactId>
 		<version>1.3.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
@@ -13,17 +13,17 @@
 	<name>Queryall Webapp library</name>
 	<dependencies>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-api</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-lib</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.queryall</groupId>
+			<groupId>com.github.queryall</groupId>
 			<artifactId>queryall-content-negotiation</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/queryall-webapp/src/main/java/org/queryall/servlets/NamespaceProvidersServlet.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/NamespaceProvidersServlet.java
@@ -97,7 +97,7 @@ public class NamespaceProvidersServlet extends HttpServlet
                 if(!providersByQueryKey.containsKey(nextQueryKey))
                 {
                     final Map<URI, Provider> queryProviders =
-                            ProviderUtils.getProvidersForQueryType(allProviders, nextQueryKey);
+                            ProviderUtils.getProvidersSupportingQueryType(allProviders, nextQueryKey);
                     
                     providersByQueryKey.put(nextQueryKey, queryProviders.values());
                     
@@ -325,7 +325,7 @@ public class NamespaceProvidersServlet extends HttpServlet
                     // localSettings.getAllQueryTypes().get(nextUniqueQueryTitle);
                     
                     final Map<URI, Provider> queryTypesForNamespace =
-                            ProviderUtils.getProvidersForQueryType(allProviders, nextUniqueQueryTitle);
+                            ProviderUtils.getProvidersSupportingQueryType(allProviders, nextUniqueQueryTitle);
                     
                     if(queryTypesForNamespace.size() > 0)
                     {

--- a/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
@@ -206,11 +206,12 @@ public class HtmlPageRenderer
         velocityContext.put("images", images);
         
         velocityContext.put("shortcut_icon", localSettings.getStringProperty(WebappConfig.SHORTCUT_ICON_PATH));
-        velocityContext.put("scripts", localSettings.getStringProperties(WebappConfig.INDEX_PAGE_SCRIPTS));
-        velocityContext.put("local_scripts", localSettings.getStringProperties(WebappConfig.INDEX_PAGE_SCRIPTS_LOCAL));
-        velocityContext.put("stylesheets", localSettings.getStringProperties(WebappConfig.INDEX_PAGE_STYLESHEETS));
+        velocityContext.put("scripts", localSettings.getStringProperties(WebappConfig.RESULTS_PAGE_SCRIPTS));
+        velocityContext
+                .put("local_scripts", localSettings.getStringProperties(WebappConfig.RESULTS_PAGE_SCRIPTS_LOCAL));
+        velocityContext.put("stylesheets", localSettings.getStringProperties(WebappConfig.RESULTS_PAGE_STYLESHEETS));
         velocityContext.put("local_stylesheets",
-                localSettings.getStringProperties(WebappConfig.INDEX_PAGE_STYLESHEETS_LOCAL));
+                localSettings.getStringProperties(WebappConfig.RESULTS_PAGE_STYLESHEETS_LOCAL));
         
         // For each URI in localSettings.IMAGE_QUERY_TYPES
         // Make sure the URI is a valid QueryType

--- a/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
@@ -18,6 +18,7 @@ import org.openrdf.repository.Repository;
 import org.queryall.api.base.QueryAllConfiguration;
 import org.queryall.api.utils.PropertyUtils;
 import org.queryall.api.utils.WebappConfig;
+import org.queryall.comparators.ContextInsensitiveStatementComparator;
 import org.queryall.query.QueryBundle;
 import org.queryall.query.RdfFetchController;
 import org.queryall.query.RdfFetcherQueryRunnable;
@@ -221,7 +222,8 @@ public class HtmlPageRenderer
         // localSettings.getProvidersForQueryTypeForNamespaceUris(String customService,
         // Collection<Collection<String>> namespaceUris, NamespaceEntry.)
         
-        final List<Statement> allStatements = RdfUtils.getAllStatementsFromRepository(nextRepository);
+        final Collection<Statement> allStatements =
+                RdfUtils.getAllStatementsFromRepository(nextRepository, new ContextInsensitiveStatementComparator());
         
         // TODO: go through the statements and check an internal label cache to see if there is an
         // existing label available


### PR DESCRIPTION
Duplicate query bundles were a result of not overriding equals and hashCode in QueryBundle, and not using a HashSet to ensure duplicates were ignored

Duplicate statements were a relatively old issue caused by the introduction of contexts to all statements to support nquads and other quads based RDF formats. The fix for these statements required duplication in memory, as java does not offer a duplicate fixing solution with ordering, so the duplicates were filtered out using a HashSet and then the statements were exported to an ArrayList and the results were sorted using a context-insensitive comparator.

Other bugs fixed since yesterday include removing the RDF/XML parsing of HTML error pages that come back with HTTP 200 as a result of misconfigured servers, none of which shall be named.

Also fixed a situation where a QueryType was being recognised even though it didn't actually correspond to anything, and the test for this behaviour which assumed that the top level query type existed, and that it would then be empty below that.
