### PR TITLE
Add HTTP 503 responses for cases where an endpoint was blacklisted causing no results

### DIFF
--- a/queryall-api/src/main/java/org/queryall/api/utils/WebappConfig.java
+++ b/queryall-api/src/main/java/org/queryall/api/utils/WebappConfig.java
@@ -219,6 +219,10 @@ public enum WebappConfig
     
     N3_URL_SUFFIX("n3UrlSuffix", ""),
     
+    NO_ACCESSIBLE_PROVIDERS_HTTP_RESPONSE_CODE("noAccessibleProvidersHttpResponseCode", 503),
+    
+    NO_ACCESSIBLE_PROVIDERS_STATIC_ADDITIONS("noAccessibleProvidersStaticAdditions", Collections.emptyList()),
+    
     NQUADS_URL_PREFIX("nquadsUrlPrefix", "nquads/"),
     
     NQUADS_URL_SUFFIX("nquadsUrlSuffix", ""),

--- a/queryall-api/src/main/java/org/queryall/exception/ProvidersBlacklistedException.java
+++ b/queryall-api/src/main/java/org/queryall/exception/ProvidersBlacklistedException.java
@@ -28,7 +28,7 @@ public class ProvidersBlacklistedException extends QueryAllException
     /**
      * @param message
      */
-    public ProvidersBlacklistedException(String message)
+    public ProvidersBlacklistedException(final String message)
     {
         super(message);
     }
@@ -37,7 +37,7 @@ public class ProvidersBlacklistedException extends QueryAllException
      * @param message
      * @param cause
      */
-    public ProvidersBlacklistedException(String message, Throwable cause)
+    public ProvidersBlacklistedException(final String message, final Throwable cause)
     {
         super(message, cause);
     }
@@ -45,7 +45,7 @@ public class ProvidersBlacklistedException extends QueryAllException
     /**
      * @param cause
      */
-    public ProvidersBlacklistedException(Throwable cause)
+    public ProvidersBlacklistedException(final Throwable cause)
     {
         super(cause);
     }

--- a/queryall-api/src/main/java/org/queryall/exception/ProvidersBlacklistedException.java
+++ b/queryall-api/src/main/java/org/queryall/exception/ProvidersBlacklistedException.java
@@ -1,0 +1,53 @@
+/**
+ * 
+ */
+package org.queryall.exception;
+
+/**
+ * This exception is thrown when at least one of the suitable providers for a query was blacklisted,
+ * and this blacklisting may have been the cause for an empty set of planned queries.
+ * 
+ * @author Peter Ansell p_ansell@yahoo.com
+ * 
+ */
+public class ProvidersBlacklistedException extends QueryAllException
+{
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 5159239822862462725L;
+    
+    /**
+     * 
+     */
+    public ProvidersBlacklistedException()
+    {
+        super();
+    }
+    
+    /**
+     * @param message
+     */
+    public ProvidersBlacklistedException(String message)
+    {
+        super(message);
+    }
+    
+    /**
+     * @param message
+     * @param cause
+     */
+    public ProvidersBlacklistedException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+    
+    /**
+     * @param cause
+     */
+    public ProvidersBlacklistedException(Throwable cause)
+    {
+        super(cause);
+    }
+    
+}

--- a/queryall-api/src/test/java/org/queryall/api/utils/test/WebappConfigTest.java
+++ b/queryall-api/src/test/java/org/queryall/api/utils/test/WebappConfigTest.java
@@ -23,7 +23,7 @@ public class WebappConfigTest
     /**
      * NOTE: This property needs to be updated if any new properties are added
      */
-    private static final int EXPECTED_CONFIG_SIZE = 118;
+    private static final int EXPECTED_CONFIG_SIZE = 120;
     
     private ValueFactory testValueFactory;
     

--- a/queryall-lib-test/src/test/java/org/queryall/blacklist/test/DummyAllBlacklistedController.java
+++ b/queryall-lib-test/src/test/java/org/queryall/blacklist/test/DummyAllBlacklistedController.java
@@ -1,0 +1,95 @@
+/**
+ * 
+ */
+package org.queryall.blacklist.test;
+
+import org.queryall.api.base.QueryAllConfiguration;
+import org.queryall.blacklist.BlacklistController;
+
+/**
+ * @author Peter Ansell p_ansell@yahoo.com
+ * 
+ */
+public class DummyAllBlacklistedController extends BlacklistController
+{
+    
+    /**
+     * @param queryAllConfiguration
+     */
+    public DummyAllBlacklistedController(QueryAllConfiguration queryAllConfiguration)
+    {
+        super(queryAllConfiguration);
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.queryall.blacklist.BlacklistController#isClientBlacklisted(java.lang.String)
+     */
+    @Override
+    public boolean isClientBlacklisted(String nextClientIPAddress)
+    {
+        return true;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * org.queryall.blacklist.BlacklistController#isClientPermanentlyBlacklisted(java.lang.String)
+     */
+    @Override
+    public boolean isClientPermanentlyBlacklisted(String nextClientIPAddress)
+    {
+        return true;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.queryall.blacklist.BlacklistController#isEndpointBlacklisted(java.lang.String)
+     */
+    @Override
+    public boolean isEndpointBlacklisted(String nextEndpointUrl)
+    {
+        return true;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.queryall.blacklist.BlacklistController#isEndpointBlacklisted(java.lang.String, int,
+     * long, boolean)
+     */
+    @Override
+    public boolean isEndpointBlacklisted(String nextEndpointUrl, int blacklistMaxAccumulatedFailures,
+            long blacklistResetPeriodMilliseconds, boolean blacklistResetClientBlacklistWithEndpoints)
+    {
+        return true;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.queryall.blacklist.BlacklistController#isUrlBlacklisted(java.lang.String)
+     */
+    @Override
+    public boolean isUrlBlacklisted(String inputUrl)
+    {
+        return true;
+    }
+    
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.queryall.blacklist.BlacklistController#isUrlBlacklisted(java.lang.String, int, long,
+     * boolean)
+     */
+    @Override
+    public boolean isUrlBlacklisted(String inputUrl, int blacklistMaxAccumulatedFailures,
+            long blacklistResetPeriodMilliseconds, boolean blacklistResetClientBlacklistWithEndpoints)
+    {
+        return true;
+    }
+    
+}

--- a/queryall-lib-test/src/test/java/org/queryall/blacklist/test/DummyAllBlacklistedController.java
+++ b/queryall-lib-test/src/test/java/org/queryall/blacklist/test/DummyAllBlacklistedController.java
@@ -16,7 +16,7 @@ public class DummyAllBlacklistedController extends BlacklistController
     /**
      * @param queryAllConfiguration
      */
-    public DummyAllBlacklistedController(QueryAllConfiguration queryAllConfiguration)
+    public DummyAllBlacklistedController(final QueryAllConfiguration queryAllConfiguration)
     {
         super(queryAllConfiguration);
     }
@@ -27,7 +27,7 @@ public class DummyAllBlacklistedController extends BlacklistController
      * @see org.queryall.blacklist.BlacklistController#isClientBlacklisted(java.lang.String)
      */
     @Override
-    public boolean isClientBlacklisted(String nextClientIPAddress)
+    public boolean isClientBlacklisted(final String nextClientIPAddress)
     {
         return true;
     }
@@ -39,7 +39,7 @@ public class DummyAllBlacklistedController extends BlacklistController
      * org.queryall.blacklist.BlacklistController#isClientPermanentlyBlacklisted(java.lang.String)
      */
     @Override
-    public boolean isClientPermanentlyBlacklisted(String nextClientIPAddress)
+    public boolean isClientPermanentlyBlacklisted(final String nextClientIPAddress)
     {
         return true;
     }
@@ -50,7 +50,7 @@ public class DummyAllBlacklistedController extends BlacklistController
      * @see org.queryall.blacklist.BlacklistController#isEndpointBlacklisted(java.lang.String)
      */
     @Override
-    public boolean isEndpointBlacklisted(String nextEndpointUrl)
+    public boolean isEndpointBlacklisted(final String nextEndpointUrl)
     {
         return true;
     }
@@ -62,8 +62,8 @@ public class DummyAllBlacklistedController extends BlacklistController
      * long, boolean)
      */
     @Override
-    public boolean isEndpointBlacklisted(String nextEndpointUrl, int blacklistMaxAccumulatedFailures,
-            long blacklistResetPeriodMilliseconds, boolean blacklistResetClientBlacklistWithEndpoints)
+    public boolean isEndpointBlacklisted(final String nextEndpointUrl, final int blacklistMaxAccumulatedFailures,
+            final long blacklistResetPeriodMilliseconds, final boolean blacklistResetClientBlacklistWithEndpoints)
     {
         return true;
     }
@@ -74,7 +74,7 @@ public class DummyAllBlacklistedController extends BlacklistController
      * @see org.queryall.blacklist.BlacklistController#isUrlBlacklisted(java.lang.String)
      */
     @Override
-    public boolean isUrlBlacklisted(String inputUrl)
+    public boolean isUrlBlacklisted(final String inputUrl)
     {
         return true;
     }
@@ -86,8 +86,8 @@ public class DummyAllBlacklistedController extends BlacklistController
      * boolean)
      */
     @Override
-    public boolean isUrlBlacklisted(String inputUrl, int blacklistMaxAccumulatedFailures,
-            long blacklistResetPeriodMilliseconds, boolean blacklistResetClientBlacklistWithEndpoints)
+    public boolean isUrlBlacklisted(final String inputUrl, final int blacklistMaxAccumulatedFailures,
+            final long blacklistResetPeriodMilliseconds, final boolean blacklistResetClientBlacklistWithEndpoints)
     {
         return true;
     }

--- a/queryall-lib-test/src/test/java/org/queryall/utils/test/QueryBundleUtilsTest.java
+++ b/queryall-lib-test/src/test/java/org/queryall/utils/test/QueryBundleUtilsTest.java
@@ -16,14 +16,18 @@ import org.junit.Test;
 import org.queryall.api.base.QueryAllConfiguration;
 import org.queryall.api.namespace.NamespaceEntry;
 import org.queryall.api.profile.Profile;
+import org.queryall.api.provider.HttpProvider;
 import org.queryall.api.provider.Provider;
 import org.queryall.api.querytype.InputQueryType;
+import org.queryall.api.test.DummyHttpProvider;
 import org.queryall.api.test.DummyProfile;
 import org.queryall.api.test.DummyProvider;
 import org.queryall.api.test.DummyQueryType;
 import org.queryall.api.utils.ProfileIncludeExclude;
 import org.queryall.api.utils.WebappConfig;
 import org.queryall.blacklist.BlacklistController;
+import org.queryall.blacklist.test.DummyAllBlacklistedController;
+import org.queryall.exception.ProvidersBlacklistedException;
 import org.queryall.exception.QueryAllException;
 import org.queryall.query.QueryBundle;
 import org.queryall.utils.QueryBundleUtils;
@@ -52,6 +56,9 @@ public class QueryBundleUtilsTest
     private String testHostName;
     private boolean testUseAllEndpointsTrue;
     private int testPageOffset1;
+    private BlacklistController testBlacklistControllerAll;
+    private InputQueryType testQueryTypeSingleProvider;
+    private HttpProvider testProviderSingleQueryType;
     
     /**
      * @throws java.lang.Exception
@@ -62,14 +69,21 @@ public class QueryBundleUtilsTest
         this.testSettingsEmpty = new Settings();
         this.testBlacklistControllerEmpty = new BlacklistController(this.testSettingsEmpty);
         
+        this.testBlacklistControllerAll = new DummyAllBlacklistedController(this.testSettingsEmpty);
+        
         this.testQueryTypeEmpty = new DummyQueryType();
         this.testQueryTypeEmpty.setKey("http://test.example.org/querybundleutilstest/querytype/empty");
+        
+        this.testQueryTypeSingleProvider = new DummyQueryType();
+        this.testQueryTypeSingleProvider.setKey("http://test.example.org/querybundleutilstest/querytype/single");
+        this.testQueryTypeSingleProvider.setIncludeDefaults(true);
+        
         this.testChosenProvidersEmpty = new ArrayList<Provider>(0);
         this.testChosenProvidersSingleTrivial = new ArrayList<Provider>(1);
         // add an instance of DummyProvider which only implements the Provider interface, so should
         // not be recognised as HttpProvider or NoCommunicationProvider, among any others
         this.testProviderTrivial1 = new DummyProvider();
-        this.testProviderTrivial1.setKey("http://test.example.org/querybundleutilstest/trivial/1");
+        this.testProviderTrivial1.setKey("http://test.example.org/querybundleutilstest/provider/trivial/1");
         this.testChosenProvidersSingleTrivial.add(this.testProviderTrivial1);
         
         this.testSortedIncludedProfilesEmpty = new ArrayList<Profile>(0);
@@ -81,6 +95,12 @@ public class QueryBundleUtilsTest
         this.testProfileSingleAllInclude
                 .setDefaultProfileIncludeExcludeOrder(ProfileIncludeExclude.EXCLUDE_THEN_INCLUDE);
         this.testSortedIncludedProfilesSingleAllInclude.add(this.testProfileSingleAllInclude);
+        
+        this.testProviderSingleQueryType = new DummyHttpProvider();
+        this.testProviderSingleQueryType.setKey("http://test.example.org/querybundleutilstest/provider/singlequerytype/1");
+        this.testProviderSingleQueryType.addIncludedInQueryType(this.testQueryTypeSingleProvider.getKey());
+        this.testProviderSingleQueryType.setIsDefaultSource(true);
+        this.testProviderSingleQueryType.addEndpointUrl("http://bad.example.org/anything/something");
         
         this.testQueryParametersEmpty = new HashMap<String, String>();
         this.testNamespaceInputVariablesEmpty = new HashMap<String, Collection<NamespaceEntry>>();
@@ -137,6 +157,37 @@ public class QueryBundleUtilsTest
         
         Assert.assertNotNull(results);
         Assert.assertEquals(0, results.size());
+    }
+    
+    /**
+     * Tests the generateQueryBundlesForQueryTypeAndProviders method with all items in their empty
+     * or freshly initialised state
+     * 
+     * @throws QueryAllException
+     * 
+     */
+    @Test
+    public final void testGenerateQueryBundlesAllEmptyWithBlacklist() throws QueryAllException
+    {
+        try
+        {
+            Collection<QueryBundle> collection = QueryBundleUtils.generateQueryBundlesForQueryTypeAndProviders(this.testQueryTypeSingleProvider,
+                    this.testChosenProvidersSingleTrivial, this.testQueryParametersEmpty,
+                    this.testNamespaceInputVariablesEmpty, this.testSortedIncludedProfilesEmpty, this.testSettingsEmpty
+                            .getAllQueryTypes(), this.testSettingsEmpty, this.testBlacklistControllerAll,
+                    this.testHostName, this.testUseAllEndpointsTrue, this.testPageOffset1, this.testSettingsEmpty
+                            .getBooleanProperty(WebappConfig.CONVERT_ALTERNATE_NAMESPACE_PREFIXES_TO_PREFERRED),
+                    this.testSettingsEmpty.getBooleanProperty(WebappConfig.RECOGNISE_IMPLICIT_RDFRULE_INCLUSIONS),
+                    this.testSettingsEmpty.getBooleanProperty(WebappConfig.INCLUDE_NON_PROFILE_MATCHED_RDFRULES));
+            
+            // FIXME: collection is coming back as size 1 for some reason
+            Assert.assertEquals(0, collection.size());
+            Assert.fail("Did not receive expected ProvidersBlacklistedException");
+        }
+        catch(ProvidersBlacklistedException pbe)
+        {
+            Assert.assertTrue(pbe.getMessage().contains(""));
+        }
     }
     
     /**

--- a/queryall-lib-test/src/test/java/org/queryall/utils/test/RuleUtilsTest.java
+++ b/queryall-lib-test/src/test/java/org/queryall/utils/test/RuleUtilsTest.java
@@ -4,7 +4,6 @@
 package org.queryall.utils.test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -62,13 +61,13 @@ public class RuleUtilsTest
     private StringRuleTest testStringRuleTestQueryVariables;
     
     private StringRuleTest testStringRuleTestBeforeResultsImport;
-
+    
     private PrefixMappingNormalisationRule testRulePrefixMatching;
-
+    
     private StringRuleTest testStringRuleTestPrefixMatching;
-
+    
     private Collection<RuleTest> testRuleTestsPrefixMatching;
-
+    
     private Map<URI, NormalisationRule> testNormalisationRulesPrefixMatching;
     
     /**
@@ -104,7 +103,8 @@ public class RuleUtilsTest
         this.testRulePrefixMatching.addStage(NormalisationRuleSchema.getRdfruleStageBeforeResultsImport());
         
         this.testNormalisationRulesPrefixMatching = new ConcurrentHashMap<URI, NormalisationRule>();
-        this.testNormalisationRulesPrefixMatching.put(this.testRulePrefixMatching.getKey(), this.testRulePrefixMatching);
+        this.testNormalisationRulesPrefixMatching
+                .put(this.testRulePrefixMatching.getKey(), this.testRulePrefixMatching);
         
         this.testNormalisationRulesEmpty = Collections.emptyMap();
         
@@ -310,7 +310,22 @@ public class RuleUtilsTest
     /**
      * Test method for
      * {@link org.queryall.utils.RuleUtils#runRuleTests(java.util.Collection, java.util.Map)}.
-     * @throws QueryAllException 
+     * 
+     * @throws QueryAllException
+     */
+    @Test
+    public void testRunRuleTestsEmptyWithoutRules() throws QueryAllException
+    {
+        final boolean runRuleTests = RuleUtils.runRuleTests(this.testRuleTestsEmpty, this.testNormalisationRulesEmpty);
+        
+        Assert.assertTrue("Empty rule test running failed", runRuleTests);
+    }
+    
+    /**
+     * Test method for
+     * {@link org.queryall.utils.RuleUtils#runRuleTests(java.util.Collection, java.util.Map)}.
+     * 
+     * @throws QueryAllException
      */
     @Test
     public void testRunRuleTestsEmptyWithRules() throws QueryAllException
@@ -323,27 +338,16 @@ public class RuleUtilsTest
     /**
      * Test method for
      * {@link org.queryall.utils.RuleUtils#runRuleTests(java.util.Collection, java.util.Map)}.
-     * @throws QueryAllException 
-     */
-    @Test
-    public void testRunRuleTestsEmptyWithoutRules() throws QueryAllException
-    {
-        final boolean runRuleTests = RuleUtils.runRuleTests(this.testRuleTestsEmpty, this.testNormalisationRulesEmpty);
-        
-        Assert.assertTrue("Empty rule test running failed", runRuleTests);
-    }
-
-    /**
-     * Test method for
-     * {@link org.queryall.utils.RuleUtils#runRuleTests(java.util.Collection, java.util.Map)}.
-     * @throws QueryAllException 
+     * 
+     * @throws QueryAllException
      */
     @Test
     public void testRunRuleTestsPrefixMatchingRule() throws QueryAllException
     {
-        final boolean runRuleTests = RuleUtils.runRuleTests(this.testRuleTestsPrefixMatching, this.testNormalisationRulesPrefixMatching);
+        final boolean runRuleTests =
+                RuleUtils.runRuleTests(this.testRuleTestsPrefixMatching, this.testNormalisationRulesPrefixMatching);
         
         Assert.assertTrue("Prefix Matching Rule Test running failed", runRuleTests);
     }
-
+    
 }

--- a/queryall-lib/src/main/java/org/queryall/blacklist/BlacklistController.java
+++ b/queryall-lib/src/main/java/org/queryall/blacklist/BlacklistController.java
@@ -715,6 +715,11 @@ public class BlacklistController
     
     public boolean isClientWhitelisted(final String nextClientIPAddress)
     {
+        if(nextClientIPAddress == null)
+        {
+            return false;
+        }
+        
         return this.getCurrentIPWhitelist().contains(nextClientIPAddress);
     }
     
@@ -726,6 +731,11 @@ public class BlacklistController
      */
     public boolean isEndpointBlacklisted(final String nextEndpointUrl)
     {
+        if(nextEndpointUrl == null)
+        {
+            return false;
+        }
+        
         final int blacklistMaxAccumulatedFailures =
                 this.localSettings.getIntProperty(WebappConfig.BLACKLIST_MAX_ACCUMULATED_FAILURES,
                         (Integer)WebappConfig.BLACKLIST_MAX_ACCUMULATED_FAILURES.getDefaultValue());
@@ -757,6 +767,11 @@ public class BlacklistController
     public boolean isEndpointBlacklisted(final String nextEndpointUrl, final int blacklistMaxAccumulatedFailures,
             final long blacklistResetPeriodMilliseconds, final boolean blacklistResetClientBlacklistWithEndpoints)
     {
+        if(nextEndpointUrl == null)
+        {
+            return false;
+        }
+        
         this.doBlacklistExpiry(blacklistResetPeriodMilliseconds, blacklistResetClientBlacklistWithEndpoints);
         
         if(this.accumulatedBlacklistStatistics.containsKey(nextEndpointUrl))
@@ -773,6 +788,8 @@ public class BlacklistController
     
     /**
      * 
+     * NOTE: If inputUrl is null, this method will always return false.
+     * 
      * @param inputUrl
      *            The full URL to check
      * 
@@ -780,6 +797,11 @@ public class BlacklistController
      */
     public boolean isUrlBlacklisted(final String inputUrl)
     {
+        if(inputUrl == null)
+        {
+            return false;
+        }
+        
         final int blacklistMaxAccumulatedFailures =
                 this.localSettings.getIntProperty(WebappConfig.BLACKLIST_MAX_ACCUMULATED_FAILURES,
                         (Integer)WebappConfig.BLACKLIST_MAX_ACCUMULATED_FAILURES.getDefaultValue());
@@ -806,6 +828,11 @@ public class BlacklistController
     public boolean isUrlBlacklisted(final String inputUrl, final int blacklistMaxAccumulatedFailures,
             final long blacklistResetPeriodMilliseconds, final boolean blacklistResetClientBlacklistWithEndpoints)
     {
+        if(inputUrl == null)
+        {
+            return false;
+        }
+        
         URL url = null;
         
         try

--- a/queryall-lib/src/main/java/org/queryall/query/QueryCreator.java
+++ b/queryall-lib/src/main/java/org/queryall/query/QueryCreator.java
@@ -155,7 +155,7 @@ public class QueryCreator
         
         final ProcessorQueryType processorQueryType = (ProcessorQueryType)queryType;
         
-        if(queryString.trim().equals(""))
+        if(queryString == null || queryString.trim().equals(""))
         {
             QueryCreator.log.error("QueryCreator.createQuery: queryString was empty");
         }
@@ -1189,8 +1189,11 @@ public class QueryCreator
                 StringUtils.percentEncode(defaultSeparator));
         attributeList.put(Constants.TEMPLATE_KEY_URL_ENCODED_ENDPOINT_URL, StringUtils.percentEncode(nextEndpoint));
         attributeList.put(Constants.TEMPLATE_KEY_URL_ENCODED_REAL_HOST_NAME, StringUtils.percentEncode(realHostName));
-        attributeList.put(Constants.TEMPLATE_KEY_URL_ENCODED_QUERY_STRING,
-                StringUtils.percentEncode(queryParameters.get(Constants.QUERY)));
+        if(queryParameters.containsKey(Constants.QUERY))
+        {
+            attributeList.put(Constants.TEMPLATE_KEY_URL_ENCODED_QUERY_STRING,
+                    StringUtils.percentEncode(queryParameters.get(Constants.QUERY)));
+        }
         
         attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_DEFAULT_HOST_NAME,
                 StringUtils.xmlEncodeString(configHostName));
@@ -1200,8 +1203,11 @@ public class QueryCreator
                 StringUtils.xmlEncodeString(defaultSeparator));
         attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_ENDPOINT_URL, StringUtils.xmlEncodeString(nextEndpoint));
         attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_REAL_HOST_NAME, StringUtils.xmlEncodeString(realHostName));
-        attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_QUERY_STRING,
-                StringUtils.xmlEncodeString(queryParameters.get(Constants.QUERY)));
+        if(queryParameters.containsKey(Constants.QUERY))
+        {
+            attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_QUERY_STRING,
+                    StringUtils.xmlEncodeString(queryParameters.get(Constants.QUERY)));
+        }
         
         attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_URL_ENCODED_DEFAULT_HOST_NAME,
                 StringUtils.xmlEncodeString(StringUtils.percentEncode(configHostName)));
@@ -1213,8 +1219,11 @@ public class QueryCreator
                 StringUtils.xmlEncodeString(StringUtils.percentEncode(nextEndpoint)));
         attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_URL_ENCODED_REAL_HOST_NAME,
                 StringUtils.xmlEncodeString(StringUtils.percentEncode(realHostName)));
-        attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_URL_ENCODED_QUERY_STRING,
-                StringUtils.xmlEncodeString(StringUtils.percentEncode(queryParameters.get(Constants.QUERY))));
+        if(queryParameters.containsKey(Constants.QUERY))
+        {
+            attributeList.put(Constants.TEMPLATE_KEY_XML_ENCODED_URL_ENCODED_QUERY_STRING,
+                    StringUtils.xmlEncodeString(StringUtils.percentEncode(queryParameters.get(Constants.QUERY))));
+        }
         
         if(QueryCreator.DEBUG)
         {
@@ -1578,7 +1587,7 @@ public class QueryCreator
     {
         final String queryString = attributeList.get(Constants.TEMPLATE_KEY_QUERY_STRING);
         
-        if(queryString.trim().equals(""))
+        if(queryString == null || queryString.trim().equals(""))
         {
             QueryCreator.log.error("QueryCreator.replaceAttributesOnEndpointUrl: queryString was empty");
         }

--- a/queryall-lib/src/main/java/org/queryall/query/RdfFetchController.java
+++ b/queryall-lib/src/main/java/org/queryall/query/RdfFetchController.java
@@ -676,6 +676,16 @@ public class RdfFetchController
                     }
                     catch(final ProvidersBlacklistedException pbe)
                     {
+                        if(RdfFetchController.INFO)
+                        {
+                            RdfFetchController.log
+                                    .info("Query type not used on any providers due to 1 or more blacklisted endpoints querytype={}",
+                                            nextInputQueryType.getKey().stringValue());
+                            if(RdfFetchController.DEBUG)
+                            {
+                                RdfFetchController.log.debug("ProvidersBlacklistedException:", pbe);
+                            }
+                        }
                         this.queryTypeWasBlacklisted = true;
                     }
                 }

--- a/queryall-lib/src/main/java/org/queryall/query/RdfFetchController.java
+++ b/queryall-lib/src/main/java/org/queryall/query/RdfFetchController.java
@@ -509,6 +509,17 @@ public class RdfFetchController
     }
     
     /**
+     * Returns true if at least one query type had no providers match, and at least one of the
+     * endpoints on one of the providers was not included due to it being blacklisted.
+     * 
+     * @return the queryTypeWasBlacklisted
+     */
+    public boolean getQueryTypeWasBlacklisted()
+    {
+        return this.queryTypeWasBlacklisted;
+    }
+    
+    /**
      * @return the realHostName
      */
     public String getRealHostName()
@@ -663,7 +674,7 @@ public class RdfFetchController
                             }
                         }
                     }
-                    catch(ProvidersBlacklistedException pbe)
+                    catch(final ProvidersBlacklistedException pbe)
                     {
                         this.queryTypeWasBlacklisted = true;
                     }
@@ -815,16 +826,5 @@ public class RdfFetchController
     public void setUncalledThreads(final Collection<RdfFetcherQueryRunnable> uncalledThreads)
     {
         this.uncalledThreads = uncalledThreads;
-    }
-    
-    /**
-     * Returns true if at least one query type had no providers match, and at least one of the
-     * endpoints on one of the providers was not included due to it being blacklisted.
-     * 
-     * @return the queryTypeWasBlacklisted
-     */
-    public boolean getQueryTypeWasBlacklisted()
-    {
-        return queryTypeWasBlacklisted;
     }
 }

--- a/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/QueryBundleUtils.java
@@ -214,15 +214,16 @@ public class QueryBundleUtils
                         
                         // Then test whether the endpoint is blacklisted before accepting it
                         // HACK: This logic should be delegated to providers
-                        boolean endpointBlacklisted = !localBlacklistController.isUrlBlacklisted(nextReplacedEndpoint);
+                        final boolean endpointBlacklisted =
+                                localBlacklistController.isUrlBlacklisted(nextReplacedEndpoint);
                         
-                        if(noCommunicationProvider || endpointBlacklisted)
+                        if(endpointBlacklisted)
                         {
-                            if(endpointBlacklisted)
-                            {
-                                ignoredBlacklistedEndpoint = true;
-                            }
-                            
+                            ignoredBlacklistedEndpoint = true;
+                        }
+                        
+                        if(noCommunicationProvider || !endpointBlacklisted)
+                        {
                             // no need to worry about redundant endpoint alternates if we are going
                             // to try to query all of the endpoints for each provider
                             // FIXME: This logic seems to be broken as the alternative endpoints are
@@ -236,7 +237,10 @@ public class QueryBundleUtils
                             }
                         }
                     }
-                    
+                }
+                
+                if(!nextProviderQueryBundle.getAlternativeEndpointsAndQueries().isEmpty())
+                {
                     results.add(nextProviderQueryBundle);
                 }
             } // end if(nextProvider instanceof HttpProvider)

--- a/queryall-lib/src/main/java/org/queryall/utils/RuleUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/RuleUtils.java
@@ -335,7 +335,7 @@ public final class RuleUtils
         
         if(nextStringRuleTest.getStages().contains(NormalisationRuleSchema.getRdfruleStageQueryVariables()))
         {
-            String nextInputTestResult = nextTestInputString;
+            String nextInputTestResult = new String(nextTestInputString);
             
             for(final NormalisationRule nextRule : RuleUtils.getSortedRulesByUris(allNormalisationRules,
                     nextStringRuleTest.getRuleUris(), SortOrder.LOWEST_ORDER_FIRST))
@@ -413,11 +413,9 @@ public final class RuleUtils
                 
                 if(RuleUtils.INFO)
                 {
-                    RuleUtils.log
-                            .info("TEST-FAIL: input test did not result in the output string: nextTestInputString="
-                                    + nextTestInputString + " actual output was nextInputTestResult="
-                                    + nextInputTestResult + " expected output was nextTestOutputString="
-                                    + nextTestOutputString);
+                    RuleUtils.log.info("TEST-FAIL: input test fail: start :: <[[" + nextTestInputString
+                            + "]]> expected output :: <[[" + nextTestOutputString + "]]> actual output :: <[["
+                            + nextInputTestResult + "]]>");
                     RuleUtils.log.info("TEST-FAIL: nextRuleTest.toString()=" + nextStringRuleTest.toString());
                 }
             }
@@ -425,7 +423,7 @@ public final class RuleUtils
         
         if(nextStringRuleTest.getStages().contains(NormalisationRuleSchema.getRdfruleStageBeforeResultsImport()))
         {
-            String nextOutputTestResult = nextTestOutputString;
+            String nextOutputTestResult = new String(nextTestOutputString);
             
             for(final NormalisationRule nextRule : RuleUtils.getSortedRulesByUris(allNormalisationRules,
                     nextStringRuleTest.getRuleUris(), SortOrder.HIGHEST_ORDER_FIRST))
@@ -469,9 +467,9 @@ public final class RuleUtils
             {
                 if(RuleUtils.DEBUG)
                 {
-                    RuleUtils.log.debug("TEST-PASS output test pass: nextTestInputString=" + nextTestInputString
-                            + " actual output :: nextOutputTestResult=" + nextOutputTestResult
-                            + " expected output :: nextTestOutputString=" + nextTestOutputString);
+                    RuleUtils.log.debug("TEST-PASS output test pass: start :: <[[" + nextTestInputString
+                            + "]]> actual output :: <[[" + nextOutputTestResult + "]]> expected output :: <[["
+                            + nextTestOutputString + "]]>");
                 }
             }
             else
@@ -480,11 +478,9 @@ public final class RuleUtils
                 
                 if(RuleUtils.INFO)
                 {
-                    RuleUtils.log
-                            .info("TEST-FAIL: output test did not result in the input string: nextTestInputString="
-                                    + nextTestInputString + " actual output :: nextOutputTestResult="
-                                    + nextOutputTestResult + " expected output :: nextTestOutputString="
-                                    + nextTestOutputString);
+                    RuleUtils.log.info("TEST-FAIL: output test failed: start :: <[[" + nextTestInputString
+                            + "]]> expected output :: <[[" + nextTestOutputString + "]]> actual output :: <[["
+                            + nextOutputTestResult+"]]>");
                     RuleUtils.log.info("TEST-FAIL: nextRuleTest.toString()=" + nextStringRuleTest.toString());
                 }
             }

--- a/queryall-lib/src/main/java/org/queryall/utils/RuleUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/RuleUtils.java
@@ -480,7 +480,7 @@ public final class RuleUtils
                 {
                     RuleUtils.log.info("TEST-FAIL: output test failed: start :: <[[" + nextTestInputString
                             + "]]> expected output :: <[[" + nextTestOutputString + "]]> actual output :: <[["
-                            + nextOutputTestResult+"]]>");
+                            + nextOutputTestResult + "]]>");
                     RuleUtils.log.info("TEST-FAIL: nextRuleTest.toString()=" + nextStringRuleTest.toString());
                 }
             }

--- a/queryall-webapp/src/main/java/org/queryall/servlets/GeneralServlet.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/GeneralServlet.java
@@ -185,7 +185,7 @@ public class GeneralServlet extends HttpServlet
             // the purposes of the query type blacklisted check
             boolean nonDummyQueryTypeFound = false;
             
-            for(QueryBundle nextQueryBundle : multiProviderQueryBundles)
+            for(final QueryBundle nextQueryBundle : multiProviderQueryBundles)
             {
                 if(!nextQueryBundle.getQueryType().getIsDummyQueryType())
                 {

--- a/queryall-webapp/src/main/java/org/queryall/servlets/GeneralServlet.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/GeneralServlet.java
@@ -181,6 +181,18 @@ public class GeneralServlet extends HttpServlet
             
             final Collection<QueryBundle> multiProviderQueryBundles = fetchController.getQueryBundles();
             
+            // if all of the query types were specified as dummy query types, then ignore them for
+            // the purposes of the query type blacklisted check
+            boolean nonDummyQueryTypeFound = false;
+            
+            for(QueryBundle nextQueryBundle : multiProviderQueryBundles)
+            {
+                if(!nextQueryBundle.getQueryType().getIsDummyQueryType())
+                {
+                    nonDummyQueryTypeFound = true;
+                }
+            }
+            
             final Collection<String> debugStrings = new ArrayList<String>(multiProviderQueryBundles.size() + 5);
             
             // We do not use the default catalina writer as it may not be UTF-8 compliant depending
@@ -204,7 +216,8 @@ public class GeneralServlet extends HttpServlet
                 ServletUtils.doQueryPretend(queryString, responseCode, pageOffset, requestedContentType,
                         multiProviderQueryBundles, myRepository, localSettings.getSeparator());
             }
-            else if(multiProviderQueryBundles.isEmpty() && fetchController.getQueryTypeWasBlacklisted())
+            else if((multiProviderQueryBundles.isEmpty() || !nonDummyQueryTypeFound)
+                    && fetchController.getQueryTypeWasBlacklisted())
             {
                 // Likely case for this is that all providers are temporarily blacklisted, so in
                 // order to avoid sending a 4XX code, we send a 5XX code here before we get to the

--- a/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
@@ -340,7 +340,7 @@ public class HtmlPageRenderer
         
         try
         {
-            if(fetchController == null || fetchController.queryKnown())
+            if(fetchController == null || (fetchController.queryKnown() && !fetchController.getQueryTypeWasBlacklisted()))
             {
                 if(HtmlPageRenderer.DEBUG)
                 {
@@ -360,6 +360,7 @@ public class HtmlPageRenderer
                     HtmlPageRenderer.log.debug("renderHtml: !fetchController.queryKnown(), using error template");
                 }
                 
+                velocityContext.put("queryTypeWasBlacklisted", fetchController.getQueryTypeWasBlacklisted());
                 velocityContext.put("namespaceRecognised", !fetchController.anyNamespaceNotRecognised());
                 velocityContext.put("queryKnown", fetchController.queryKnown());
                 

--- a/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
@@ -340,7 +340,8 @@ public class HtmlPageRenderer
         
         try
         {
-            if(fetchController == null || (fetchController.queryKnown() && !fetchController.getQueryTypeWasBlacklisted()))
+            if(fetchController == null
+                    || (fetchController.queryKnown() && !fetchController.getQueryTypeWasBlacklisted()))
             {
                 if(HtmlPageRenderer.DEBUG)
                 {

--- a/queryall-webapp/src/main/java/org/queryall/servlets/utils/ServletUtils.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/utils/ServletUtils.java
@@ -35,13 +35,13 @@ import org.queryall.api.utils.SortOrder;
 import org.queryall.api.utils.WebappConfig;
 import org.queryall.blacklist.BlacklistController;
 import org.queryall.exception.QueryAllException;
+import org.queryall.exception.QueryAllRuntimeException;
 import org.queryall.exception.UnnormalisableRuleException;
 import org.queryall.query.QueryBundle;
 import org.queryall.query.QueryCreator;
 import org.queryall.query.QueryDebug;
 import org.queryall.query.RdfFetchController;
 import org.queryall.query.RdfFetcherQueryRunnable;
-import org.queryall.servlets.GeneralServlet;
 import org.queryall.servlets.html.HtmlPageRenderer;
 import org.queryall.servlets.queryparsers.DefaultQueryOptions;
 import org.queryall.utils.RdfUtils;
@@ -58,6 +58,9 @@ import org.slf4j.LoggerFactory;
 public class ServletUtils
 {
     private static final Logger log = LoggerFactory.getLogger(ServletUtils.class);
+    private static final boolean TRACE = ServletUtils.log.isTraceEnabled();
+    private static final boolean DEBUG = ServletUtils.log.isDebugEnabled();
+    private static final boolean INFO = ServletUtils.log.isInfoEnabled();
     
     /**
      * @param response
@@ -84,12 +87,12 @@ public class ServletUtils
                 ServletUtils.getRedirectString(redirectString, localSettings, requestQueryOptions,
                         requestedContentType, ignoreContextPath, contextPath);
                 
-                if(GeneralServlet.INFO)
+                if(ServletUtils.INFO)
                 {
                     ServletUtils.log.info("Sending redirect using redirectCode=" + redirectCode + " to redirectString="
                             + redirectString.toString());
                 }
-                if(GeneralServlet.DEBUG)
+                if(ServletUtils.DEBUG)
                 {
                     ServletUtils.log.debug("contextPath=" + contextPath);
                 }
@@ -203,7 +206,7 @@ public class ServletUtils
             // Attempt to fetch information as needed
             fetchController.fetchRdfForQueries();
             
-            if(GeneralServlet.INFO)
+            if(ServletUtils.INFO)
             {
                 if(requestedContentType.equals(Constants.APPLICATION_RDF_XML)
                         || requestedContentType.equals(Constants.TEXT_HTML))
@@ -218,7 +221,7 @@ public class ServletUtils
             
             for(final RdfFetcherQueryRunnable nextResult : fetchController.getResults())
             {
-                if(GeneralServlet.INFO)
+                if(ServletUtils.INFO)
                 {
                     if(requestedContentType.equals(Constants.APPLICATION_RDF_XML)
                             || requestedContentType.equals(Constants.TEXT_HTML))
@@ -234,7 +237,7 @@ public class ServletUtils
                     }
                 }
                 
-                if(GeneralServlet.TRACE)
+                if(ServletUtils.TRACE)
                 {
                     ServletUtils.log.trace("GeneralServlet: normalised result string : "
                             + nextResult.getNormalisedResult());
@@ -257,7 +260,7 @@ public class ServletUtils
                                         .getBooleanProperty(WebappConfig.RECOGNISE_IMPLICIT_RDFRULE_INCLUSIONS),
                                 localSettings.getBooleanProperty(WebappConfig.INCLUDE_NON_PROFILE_MATCHED_RDFRULES));
                 
-                if(GeneralServlet.DEBUG)
+                if(ServletUtils.DEBUG)
                 {
                     final RepositoryConnection tempRepositoryConnection = tempRepository.getConnection();
                     
@@ -274,7 +277,7 @@ public class ServletUtils
             {
                 String nextStaticString = nextPotentialQueryBundle.getStaticRdfXmlString();
                 
-                if(GeneralServlet.TRACE)
+                if(ServletUtils.TRACE)
                 {
                     ServletUtils.log
                             .trace("GeneralServlet: Adding static RDF/XML string nextPotentialQueryBundle.getQueryType().getKey()="
@@ -365,7 +368,7 @@ public class ServletUtils
                     SettingsFactory.CONFIG_API_VERSION);
         }
         
-        if(GeneralServlet.TRACE)
+        if(ServletUtils.TRACE)
         {
             ServletUtils.log.trace("GeneralServlet: Finished with pretend query bundle rdf generation");
         }
@@ -387,7 +390,8 @@ public class ServletUtils
      */
     public static void doQueryUnknown(final QueryAllConfiguration localSettings, final String realHostName,
             final Map<String, String> queryParameters, final int pageOffset, final String requestedContentType,
-            final List<Profile> includedProfiles, final RdfFetchController fetchController,
+            final List<Profile> includedProfiles, final boolean anyNamespaceNotRecognised,
+            final boolean queryNotRecognised, final boolean noAccessibleProviders,
             final Collection<String> debugStrings, final Repository myRepository) throws IOException,
         RepositoryException, QueryAllException
     {
@@ -404,21 +408,31 @@ public class ServletUtils
             
             Collection<URI> staticQueryTypesForUnknown;
             
-            // TODO: attempt to generate a non-empty namespaceEntryMap in this case??
-            if(fetchController.anyNamespaceNotRecognised())
+            if(noAccessibleProviders)
             {
+                // TODO: attempt to generate a non-empty namespaceEntryMap in this case
+                staticQueryTypesForUnknown =
+                        localSettings.getURIProperties(WebappConfig.NO_ACCESSIBLE_PROVIDERS_STATIC_ADDITIONS);
+            }
+            else if(anyNamespaceNotRecognised)
+            {
+                // TODO: attempt to generate a non-empty namespaceEntryMap in this case??
                 staticQueryTypesForUnknown =
                         localSettings.getURIProperties(WebappConfig.UNKNOWN_NAMESPACE_STATIC_ADDITIONS);
             }
-            else
+            else if(queryNotRecognised)
             {
                 staticQueryTypesForUnknown =
                         localSettings.getURIProperties(WebappConfig.UNKNOWN_QUERY_STATIC_ADDITIONS);
             }
+            else
+            {
+                throw new QueryAllRuntimeException("Did not recognise the type of error in doQueryUnknown");
+            }
             
             for(final URI nextStaticQueryTypeForUnknown : staticQueryTypesForUnknown)
             {
-                if(GeneralServlet.DEBUG)
+                if(ServletUtils.DEBUG)
                 {
                     ServletUtils.log.debug("GeneralServlet: nextStaticQueryTypeForUnknown="
                             + nextStaticQueryTypeForUnknown);
@@ -430,9 +444,8 @@ public class ServletUtils
                 {
                     throw new QueryAllException(
                             "Could not find query type for static unknown query type nextStaticQueryTypeForUnknown="
-                                    + nextStaticQueryTypeForUnknown.stringValue()
-                                    + " fetchController.anyNamespaceNotRecognised()="
-                                    + fetchController.anyNamespaceNotRecognised());
+                                    + nextStaticQueryTypeForUnknown.stringValue() + " anyNamespaceNotRecognised="
+                                    + anyNamespaceNotRecognised);
                 }
                 
                 // If we didn't understand the query
@@ -449,6 +462,8 @@ public class ServletUtils
                     // This is a last ditch solution to giving some meaningful feedback, as we
                     // assume that the unknown query type will handle the input, so we pass it in as
                     // both parameters
+                    // NOTE: An empty NamespaceEntry Map is currently always provided to this
+                    // method, so static strings should not rely on namespace-related placeholders
                     String nextBackupString =
                             QueryCreator
                                     .createStaticRdfXmlString(
@@ -471,6 +486,7 @@ public class ServletUtils
                     
                     try
                     {
+                        // FIXME: Allow for other serialisation formats for static strings
                         myRepositoryConnection.add(new java.io.StringReader(nextBackupString),
                                 localSettings.getDefaultHostAddress() + queryParameters.get(Constants.QUERY),
                                 RDFFormat.RDFXML, nextIncludeType.getKey());
@@ -502,11 +518,6 @@ public class ServletUtils
                 {
                     debugStrings.add("# Could not find anything at all to match at query level");
                 }
-            }
-            
-            if(GeneralServlet.TRACE)
-            {
-                ServletUtils.log.trace("GeneralServlet: ending !fetchController.queryKnown() section");
             }
         }
         finally
@@ -659,7 +670,7 @@ public class ServletUtils
             final String requestedContentType, final boolean containsExplicitPageOffset, final String acceptHeader,
             final String userAgentHeader)
     {
-        if(GeneralServlet.INFO)
+        if(ServletUtils.INFO)
         {
             ServletUtils.log.info("GeneralServlet: query started on " + serverName + " requesterIpAddress="
                     + requesterIpAddress + " queryString=" + queryString + " explicitPageOffset="
@@ -706,7 +717,7 @@ public class ServletUtils
         // TODO: Make this process generic to allow output to arbitrary formats instead of just
         if(requestedContentType.equals(Constants.TEXT_HTML))
         {
-            if(GeneralServlet.DEBUG)
+            if(ServletUtils.DEBUG)
             {
                 ServletUtils.log.debug("GeneralServlet: about to call html rendering method");
                 ServletUtils.log.debug("GeneralServlet: fetchController.queryKnown()=" + fetchController.queryKnown());
@@ -729,7 +740,7 @@ public class ServletUtils
         }
         else
         {
-            if(GeneralServlet.DEBUG)
+            if(ServletUtils.DEBUG)
             {
                 ServletUtils.log.debug("GeneralServlet: about to call rdf rendering method");
                 ServletUtils.log.debug("GeneralServlet: fetchController.queryKnown()=" + fetchController.queryKnown());


### PR DESCRIPTION
Note, this code only returns HTTP 503 responses in cases where at least one endpoint was blacklisted and there were no results. This makes sure that invalid queries are still 4xx based so that users do not keep trying to access queries that were completely unrecognised.
