### PR TITLE
Fix logging in production

### DIFF
--- a/queryall-ext-rule-spin/src/main/java/org/queryall/impl/rdfrule/SpinUtils.java
+++ b/queryall-ext-rule-spin/src/main/java/org/queryall/impl/rdfrule/SpinUtils.java
@@ -155,7 +155,7 @@ public class SpinUtils
             }
         }
         
-        Graph createGraph = SesameJena.createGraph(outputRepository.getValueFactory(), inputModel);
+        final Graph createGraph = SesameJena.createGraph(outputRepository.getValueFactory(), inputModel);
         
         RepositoryConnection connection = null;
         

--- a/queryall-lib/src/main/java/org/queryall/query/RdfFetcherQueryRunnableImpl.java
+++ b/queryall-lib/src/main/java/org/queryall/query/RdfFetcherQueryRunnableImpl.java
@@ -555,7 +555,7 @@ public abstract class RdfFetcherQueryRunnableImpl extends Thread implements RdfF
     @Override
     public String toString()
     {
-        return "originalendpointUrl=" + this.getOriginalEndpointUrl() + "actualendpointurl="
+        return "originalendpointUrl=" + this.getOriginalEndpointUrl() + " actualendpointurl="
                 + this.getActualEndpointUrl() + " query=" + this.getOriginalQuery();
     }
     

--- a/queryall-lib/src/main/java/org/queryall/query/RdfFetcherSparqlQueryRunnableImpl.java
+++ b/queryall-lib/src/main/java/org/queryall/query/RdfFetcherSparqlQueryRunnableImpl.java
@@ -54,6 +54,7 @@ public class RdfFetcherSparqlQueryRunnableImpl extends RdfFetcherQueryRunnableIm
             
             this.setQueryStartTime(new Date());
             
+            // FIXME: If this throws an exception, then the alternates are not going to be used
             String tempRawResult =
                     fetcher.submitSparqlQuery(this.getOriginalEndpointUrl(), "", this.getOriginalQuery(), "",
                             this.maxRowsParameter, this.getAcceptHeader());
@@ -66,15 +67,23 @@ public class RdfFetcherSparqlQueryRunnableImpl extends RdfFetcherQueryRunnableIm
                 final Map<String, String> alternateEndpointsAndQueries =
                         this.getOriginalQueryBundle().getAlternativeEndpointsAndQueries();
                 
-                RdfFetcherSparqlQueryRunnableImpl.log.error("There are " + (alternateEndpointsAndQueries.size() - 1)
-                        + " alternative endpoints to choose from");
+                if(RdfFetcherSparqlQueryRunnableImpl.DEBUG)
+                {
+                    // hide this in production, but show up as ERROR in testing
+                    RdfFetcherSparqlQueryRunnableImpl.log.error("There are "
+                            + (alternateEndpointsAndQueries.size() - 1) + " alternative endpoints to choose from");
+                }
                 
                 for(final String alternateEndpoint : alternateEndpointsAndQueries.keySet())
                 {
                     if(!alternateEndpoint.equals(this.getOriginalEndpointUrl()))
                     {
-                        RdfFetcherSparqlQueryRunnableImpl.log.error("Trying to fetch from alternate endpoint="
-                                + alternateEndpoint + " originalEndpoint=" + this.getOriginalEndpointUrl());
+                        if(RdfFetcherSparqlQueryRunnableImpl.DEBUG)
+                        {
+                            // hide this in production, but show up as ERROR in testing
+                            RdfFetcherSparqlQueryRunnableImpl.log.error("Trying to fetch from alternate endpoint="
+                                    + alternateEndpoint + " originalEndpoint=" + this.getOriginalEndpointUrl());
+                        }
                         
                         final String alternateQuery = alternateEndpointsAndQueries.get(alternateEndpoint);
                         
@@ -89,8 +98,12 @@ public class RdfFetcherSparqlQueryRunnableImpl extends RdfFetcherQueryRunnableIm
                         
                         if(!fetcher.getLastWasError())
                         {
-                            RdfFetcherSparqlQueryRunnableImpl.log.error("Found a success with alternateEndpoint="
-                                    + alternateEndpoint + " alternateQuery=" + alternateQuery);
+                            if(RdfFetcherSparqlQueryRunnableImpl.DEBUG)
+                            {
+                                RdfFetcherSparqlQueryRunnableImpl.log.error("Found a success with alternateEndpoint="
+                                        + alternateEndpoint + " alternateQuery=" + alternateQuery);
+                            }
+                            
                             // break on the first alternate that wasn't an error
                             this.setActualEndpointUrl(alternateEndpoint);
                             this.setActualQuery(alternateQuery);

--- a/queryall-lib/src/main/java/org/queryall/utils/QueryTypeUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/QueryTypeUtils.java
@@ -116,10 +116,10 @@ public final class QueryTypeUtils
                         {
                             results.put(nextQuery, actualNamespaceEntries);
                         }
-                        else if(QueryTypeUtils.INFO)
+                        else if(QueryTypeUtils.DEBUG)
                         {
                             QueryTypeUtils.log
-                                    .info("No namespace parameters matched for a namespace specific query, so not including this query type nextQuery={}",
+                                    .warn("No namespace parameters matched for a namespace specific query, so not including this query type nextQuery={}",
                                             nextQuery.getKey().stringValue());
                         }
                     }
@@ -175,8 +175,12 @@ public final class QueryTypeUtils
                         
                         results.put(nextNamespaceParameter, namespacePrefixMap.get(nextNamespaceParameterMatch));
                     }
-                    else
+                    else if(QueryTypeUtils.DEBUG)
                     {
+                        // NOTE: This represents an error, but it may flood the logs if people
+                        // request things with namespaces that do not exist in the configuration
+                        // During debugging it will show up as an ERROR, but will be silently
+                        // ignored in production
                         QueryTypeUtils.log.error("Could not find a matching namespace for nextNamespaceParameter="
                                 + nextNamespaceParameter + " nextNamespaceParameterMatch="
                                 + nextNamespaceParameterMatch);

--- a/queryall-lib/src/main/java/org/queryall/utils/RdfUtils.java
+++ b/queryall-lib/src/main/java/org/queryall/utils/RdfUtils.java
@@ -2993,8 +2993,10 @@ public final class RdfUtils
                 }
                 myRepositoryConnection.commit();
             }
-            else
+            else if(RdfUtils.DEBUG)
             {
+                // Hiding this message in production, in debugging it will show up as WARN in error
+                // logs
                 RdfUtils.log
                         .warn("Not adding anything for next result as the result was empty or the format was not understood");
             }

--- a/queryall-webapp/src/main/java/org/queryall/servlets/GeneralServlet.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/GeneralServlet.java
@@ -337,17 +337,17 @@ public class GeneralServlet extends HttpServlet
                 
                 ServletUtils.doQueryNotPretend(localSettings, queryString, requestedContentType, includedProfiles,
                         fetchController, multiProviderQueryBundles, debugStrings, myRepository);
-
+                
                 if(GeneralServlet.TRACE)
                 {
-                    GeneralServlet.log.trace("GeneralServlet: ending fetchController.queryKnown() and not pretend query section");
+                    GeneralServlet.log
+                            .trace("GeneralServlet: ending fetchController.queryKnown() and not pretend query section");
                 }
             }
             
             if(GeneralServlet.DEBUG)
             {
-                GeneralServlet.log
-                        .debug("GeneralServlet: about to normalise pool data");
+                GeneralServlet.log.debug("GeneralServlet: about to normalise pool data");
             }
             
             // Normalisation Stage : after results to pool

--- a/queryall-webapp/src/main/java/org/queryall/servlets/RobotsTxtServlet.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/RobotsTxtServlet.java
@@ -192,6 +192,8 @@ public class RobotsTxtServlet extends HttpServlet
         out.write("Disallow: /nquads/countlinks/\n");
         out.write("Disallow: /nquads/countlinksns/\n\n");
         
+        out.write("Crawl-Delay: 10");
+        
         out.flush();
     }
     

--- a/queryall-webapp/src/main/java/org/queryall/servlets/RobotsTxtServlet.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/RobotsTxtServlet.java
@@ -192,7 +192,7 @@ public class RobotsTxtServlet extends HttpServlet
         out.write("Disallow: /nquads/countlinks/\n");
         out.write("Disallow: /nquads/countlinksns/\n\n");
         
-        out.write("Crawl-Delay: 10");
+        out.write("Crawl-delay: 10");
         
         out.flush();
     }

--- a/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
+++ b/queryall-webapp/src/main/java/org/queryall/servlets/html/HtmlPageRenderer.java
@@ -1,7 +1,6 @@
 package org.queryall.servlets.html;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -53,9 +52,9 @@ public class HtmlPageRenderer
             final String queryString, final String resolvedUri, String realHostName, String contextPath,
             int pageoffset, final Collection<String> debugStrings) throws OpenRDFException
     {
-        if(DEBUG)
+        if(HtmlPageRenderer.DEBUG)
         {
-            log.debug("Entering renderHtml");
+            HtmlPageRenderer.log.debug("Entering renderHtml");
         }
         boolean nextpagelinkuseful = false;
         boolean previouspagelinkuseful = false;
@@ -168,9 +167,9 @@ public class HtmlPageRenderer
         
         velocityContext.put("provider_endpoints", endpointsList);
         
-        if(DEBUG)
+        if(HtmlPageRenderer.DEBUG)
         {
-            log.debug("About to get query bundles from fetch controller");
+            HtmlPageRenderer.log.debug("About to get query bundles from fetch controller");
         }
         
         if(fetchController != null)
@@ -178,9 +177,9 @@ public class HtmlPageRenderer
             velocityContext.put("query_bundles", fetchController.getQueryBundles());
         }
         
-        if(DEBUG)
+        if(HtmlPageRenderer.DEBUG)
         {
-            log.debug("Finished getting query bundles from fetch controller");
+            HtmlPageRenderer.log.debug("Finished getting query bundles from fetch controller");
         }
         
         // Collection<Value> titles = new HashSet<Value>();
@@ -197,14 +196,14 @@ public class HtmlPageRenderer
                 ListUtils.randomiseCollectionLayout(RdfUtils.getValuesFromRepositoryByPredicateUris(nextRepository,
                         localSettings.getURIProperties(WebappConfig.IMAGE_PROPERTIES)));
         
-        if(DEBUG)
+        if(HtmlPageRenderer.DEBUG)
         {
-            log.debug("Finished getting titles comments and images from repository");
+            HtmlPageRenderer.log.debug("Finished getting titles comments and images from repository");
         }
         
         String chosenTitle = "";
         
-        for(Value nextTitle : titles)
+        for(final Value nextTitle : titles)
         {
             chosenTitle = RdfUtils.getUTF8StringValueFromSesameValue(nextTitle);
             
@@ -243,9 +242,9 @@ public class HtmlPageRenderer
         // localSettings.getProvidersForQueryTypeForNamespaceUris(String customService,
         // Collection<Collection<String>> namespaceUris, NamespaceEntry.)
         
-        if(DEBUG)
+        if(HtmlPageRenderer.DEBUG)
         {
-            log.debug("About to get all statements from repository");
+            HtmlPageRenderer.log.debug("About to get all statements from repository");
         }
         
         final Collection<Statement> allStatements =


### PR DESCRIPTION
Log levels for some errors have been changed to be effectively debug, even though they come out in the test logs with ERROR or WARN messages. This is because many of these errors can be triggered by users, or they can make bad situations worse in times of high load, so although they are legitimate errors, they do not need to be logged in production.

Also added Crawl-delay to robots.txt with a fixed value of 10 seconds currently. TODO: Make crawl-delay number configurable in future
